### PR TITLE
provide a placeholder value

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,19 +86,16 @@ inc(7);
 One may wish to partially apply a function whose parameters are in the "wrong"
 order. All functions defined via sanctuary-def accommodate this by accepting
 "placeholders". A placeholder is an object with a `'@@functional/placeholder'`
-property whose value is `true`. [`R.__`][R.__] is one such object.
-A placeholder indicates an argument yet to be provided. For example:
+property whose value is `true`. `$.__` is one such object. A placeholder
+indicates an argument yet to be provided. For example:
 
 ```javascript
-//    _ :: Placeholder
-const _ = {'@@functional/placeholder': true};
-
 //    concatS :: String -> String -> String
 const concatS =
 def('concatS', {}, [$.String, $.String, $.String], (x, y) => x + y);
 
 //    exclaim :: String -> String
-const exclaim = concatS(_, '!');
+const exclaim = concatS($.__, '!');
 
 exclaim('ahoy');
 // => 'ahoy!'
@@ -1032,7 +1029,6 @@ Multiple constraints may be placed on a type variable by including multiple
 
 [FL:Semigroup]:     https://github.com/fantasyland/fantasy-land#semigroup
 [Object.create]:    https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/create
-[R.__]:             http://ramdajs.com/docs/#__
 [R.toString]:       http://ramdajs.com/docs/#toString
 [SyntaxError]:      https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SyntaxError
 [TypeError]:        https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypeError

--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@
 
   'use strict';
 
-  var $ = {};
+  var $ = {__: {'@@functional/placeholder': true}};
 
   var MAX_SAFE_INTEGER = Math.pow(2, 53) - 1;
   var MIN_SAFE_INTEGER = -MAX_SAFE_INTEGER;

--- a/test/index.js
+++ b/test/index.js
@@ -348,9 +348,9 @@ describe('def', function() {
     var triple =
     def('triple', {}, [$.Number, $.Number, $.Number, $.Array($.Number)], list);
 
-    eq(triple(R.__, R.__, 3)(R.__, 2)(1), [1, 2, 3]);
+    eq(triple($.__, $.__, 3)($.__, 2)(1), [1, 2, 3]);
 
-    throws(function() { triple(R.__, /x/); },
+    throws(function() { triple($.__, /x/); },
            errorEq(TypeError,
                    'Invalid value\n' +
                    '\n' +
@@ -362,7 +362,7 @@ describe('def', function() {
                    '\n' +
                    'The value at position 1 is not a member of ‘Number’.\n'));
 
-    throws(function() { triple(R.__, R.__, /x/); },
+    throws(function() { triple($.__, $.__, /x/); },
            errorEq(TypeError,
                    'Invalid value\n' +
                    '\n' +
@@ -374,7 +374,7 @@ describe('def', function() {
                    '\n' +
                    'The value at position 1 is not a member of ‘Number’.\n'));
 
-    throws(function() { triple(R.__, 2, 3)(/x/); },
+    throws(function() { triple($.__, 2, 3)(/x/); },
            errorEq(TypeError,
                    'Invalid value\n' +
                    '\n' +
@@ -584,14 +584,14 @@ describe('def', function() {
     var a000 = def('a00', {}, [a, a, a, $.Array(a)], Array);
     var anum = a000(1);
     var astr = a000('a');
-    var bstr = a000(R.__, 'b');
+    var bstr = a000($.__, 'b');
     var abstr = astr('b');
 
     eq(anum(2, 3), [1, 2, 3]);
     eq(anum(2)(3), [1, 2, 3]);
     eq(astr('b', 'c'), ['a', 'b', 'c']);
     eq(bstr('a', 'c'), ['a', 'b', 'c']);
-    eq(astr(R.__, 'c')('b'), ['a', 'b', 'c']);
+    eq(astr($.__, 'c')('b'), ['a', 'b', 'c']);
     eq(abstr('c'), ['a', 'b', 'c']);
   });
 
@@ -1432,7 +1432,7 @@ describe('def', function() {
     def('values',
         {},
         [$.StrMap(a), $.Array(a)],
-        function(m) { return R.map(R.prop(R.__, m), keys(m)); });
+        function(m) { return R.map(R.prop($.__, m), keys(m)); });
 
     var o = Object.create(null);
     o.x = 1;
@@ -1622,7 +1622,7 @@ describe('def', function() {
                    '\n' +
                    'Since there is no type of which all the above values are members, the type-variable constraint has been violated.\n'));
 
-    throws(function() { aa(R.__, 0)(/x/); },
+    throws(function() { aa($.__, 0)(/x/); },
            errorEq(TypeError,
                    'Type-variable constraint violation\n' +
                    '\n' +
@@ -2254,7 +2254,7 @@ describe('def', function() {
                    '\n' +
                    '‘or’ requires ‘a’ to satisfy the Alternative type-class constraint; the value at position 1 does not.\n'));
 
-    throws(function() { or(R.__, Right(1)); },
+    throws(function() { or($.__, Right(1)); },
            errorEq(TypeError,
                    'Type-class constraint violation\n' +
                    '\n' +
@@ -2290,7 +2290,7 @@ describe('def', function() {
                    '\n' +
                    '‘concat’ requires ‘a’ to satisfy the Semigroup type-class constraint; the value at position 1 does not.\n'));
 
-    throws(function() { concat(R.__, /x/); },
+    throws(function() { concat($.__, /x/); },
            errorEq(TypeError,
                    'Type-class constraint violation\n' +
                    '\n' +


### PR DESCRIPTION
With sanctuary-js/sanctuary#216, Sanctuary is becoming more an alternative to Ramda rather than a complement. It doesn't make sense to continue to rely on Ramda to provide the placeholder value. I found myself defining `S.__` but then realized that the placeholder should be defined here since it is sanctuary-def which actually makes use of it. It's probably still a good idea to define `S.__`, but we can simply make it an :alien: once `$.__` is defined.
