### PR TITLE
define ‘toString’ for functions returned by ‘def’

### DIFF
--- a/index.js
+++ b/index.js
@@ -1209,6 +1209,17 @@
     }, '').join('\n    ');
   };
 
+  //  typeSignature :: ... -> String
+  var typeSignature = function(
+    name,           // :: String
+    constraints,    // :: StrMap (Array TypeClass)
+    expTypes        // :: Array Type
+  ) {
+    return name + ' :: ' +
+             constraintsRepr(constraints, id, K(K(id))) +
+             expTypes.map(showType).join(' -> ');
+  };
+
   //  _underline :: ... -> String
   var _underline = function recur(
     t,              // :: Type
@@ -1247,9 +1258,7 @@
       };
     }, {carets: [], numbers: [], counter: 0});
 
-    return name + ' :: ' +
-             constraintsRepr(constraints, id, K(K(id))) +
-             expTypes.map(showType).join(' -> ') + '\n' +
+    return typeSignature(name, constraints, expTypes) + '\n' +
            _(name + ' :: ') +
              constraintsRepr(constraints, _, underlineConstraint) +
              st.carets.join(_(' -> ')) + '\n' +
@@ -1468,7 +1477,7 @@
       _indexes,     // :: Array Integer
       impl          // :: Function
     ) {
-      return arity(_indexes.length, function() {
+      var curried = arity(_indexes.length, function() {
         if (checkTypes) {
           var delta = _indexes.length - arguments.length;
           if (delta < 0) {
@@ -1535,6 +1544,9 @@
                        impl);
         }
       });
+      curried.inspect =
+      curried.toString = always(typeSignature(name, constraints, expTypes));
+      return curried;
     };
 
     return function def(name, constraints, expTypes, impl) {

--- a/test/index.js
+++ b/test/index.js
@@ -286,6 +286,18 @@ describe('def', function() {
                    '‘def’ cannot define a function with arity greater than nine'));
   });
 
+  it('returns a function with "inspect" and "toString" methods', function() {
+    //  add :: Number -> Number -> Number
+    var add =
+    def('add',
+        {},
+        [$.Number, $.Number, $.Number],
+        function(x, y) { return x + y; });
+
+    eq(add.inspect(), 'add :: Number -> Number -> Number');
+    eq(add.toString(), 'add :: Number -> Number -> Number');
+  });
+
   it('returns a curried function', function() {
     eq($2(1).length, 1);
     eq($3(1).length, 2);


### PR DESCRIPTION
Sanctuary's test suite is testing too many things. Initially the currying and type-checking code lived in Sanctuary, so it was important to test this code thoroughly in Sanctuary's test suite. Now this code lives in sanctuary-def, and sanctuary-def has its own test suite.

What does this (Sanctuary) test verify?

```javascript
throws(function() { S.add(1, Infinity); },
       errorEq(TypeError,
               'Invalid value\n' +
               '\n' +
               'add :: FiniteNumber -> FiniteNumber -> FiniteNumber\n' +
               '                       ^^^^^^^^^^^^\n' +
               '                            1\n' +
               '\n' +
               '1)  Infinity :: Number, ValidNumber\n' +
               '\n' +
               'The value at position 1 is not a member of ‘FiniteNumber’.\n'));
```

It verifies two things:

  - the type of `S.add` is `FiniteNumber -> FiniteNumber -> FiniteNumber`; and
  - `Infinity` is not a member of `FiniteNumber`.

`FiniteNumber` is defined and tested in sanctuary-def, so it's not necessary to test it in the Sanctuary test suite as well.

It *is* useful to verify the type of `S.add`, but throwing and catching an exception is an awfully roundabout way of doing so. If `S.add.toString()` were to evaluate to `'add :: FiniteNumber -> FiniteNumber -> FiniteNumber'`, we could replace the test case above with the following:

```javascript
eq(S.add.toString(), 'add :: FiniteNumber -> FiniteNumber -> FiniteNumber');
```

This would also be useful when debugging and when working in the REPL. By defining `inspect` as well as `toString`, one could trivially access a function's type signature:

```
> S.map
map :: Functor f => (a -> b) -> f a -> f b
```

Pretty neat!
