### PR TITLE
only determine actual types when necessary

### DIFF
--- a/index.js
+++ b/index.js
@@ -1023,8 +1023,7 @@
           }, Right({typeVarMap: typeVarMap, types: [expType]}));
 
         default:
-          return Right({typeVarMap: typeVarMap,
-                        types: determineActualTypesStrict(env, env, values)});
+          return Right({typeVarMap: typeVarMap, types: [expType]});
       }
     };
   };

--- a/test/index.js
+++ b/test/index.js
@@ -2557,6 +2557,29 @@ describe('def', function() {
            'The value at position 1 is not a member of ‘FiniteNumber’.\n');
   });
 
+  it('only determines actual types when necessary', function() {
+    //  count :: Integer
+    var count = 0;
+
+    //  Void :: Type
+    var Void = $.NullaryType('my-package/Void', function(x) { count += 1; return false; });
+
+    var env = [$.Array, Maybe, $.Number, Void];
+    var def = $.create({checkTypes: true, env: env});
+
+    //  head :: Array a -> Maybe a
+    var head =
+    def('head',
+        {},
+        [$.Array(a), Maybe(a)],
+        function(xs) { return xs.length > 0 ? Just(xs[0]) : Nothing; });
+
+    eq(head([]), Nothing);
+    eq(count, 0);
+    eq(head([1, 2, 3]), Just(1));
+    eq(count, 1);
+  });
+
 });
 
 describe('test', function() {


### PR DESCRIPTION
Closes #16; closes #76

Commit message:

> In order to reach the default case `expType` must be an enumerable type, a function type, or a nullary type. It therefore contains no immediately resolvable type variables, so we needn't determine all the types of which all the given values are members.

I'm slightly embarrassed by how straightforward this fix turned out to be! With this project I often need to spend several hours loading everything into (my) memory before becoming productive. :bulb:
