### PR TITLE
readme: integrate Transcribe

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,8 @@
 # Contributing
 
+Note: __README.md__ is generated from comments in __index.js__. Do not modify
+__README.md__ directly.
+
 1.  Update local master branch:
 
         $ git checkout master

--- a/index.js
+++ b/index.js
@@ -1,3 +1,147 @@
+/*              ___                 ______
+               /  /\               /  ___/\
+        ______/  / / _______    __/  /___\/
+       /  ___   / / /  ___  \  /_   __/\
+      /  /\_/  / / /  /__/  /\ \/  /\_\/
+     /  / //  / / /  ______/ / /  / /
+    /  /_//  / / /  /______\/ /  / /
+    \_______/ /  \_______/\  /__/ /
+     \______\/    \______\/  \__*/
+
+//. # sanctuary-def
+//.
+//. sanctuary-def is a run-time type system for JavaScript. It facilitates
+//. the definition of curried JavaScript functions which are explicit about
+//. the number of arguments to which they may be applied and the types of
+//. those arguments.
+//.
+//. It is conventional to import the package as `$`:
+//.
+//. ```javascript
+//. const $ = require('sanctuary-def');
+//. ```
+//.
+//. The next step is to define an environment. An environment is an array
+//. of [types][]. [`env`][] is an environment containing all the built-in
+//. JavaScript types. It may be used as the basis for environments which
+//. include custom types in addition to the built-in types:
+//.
+//. ```javascript
+//. //    Integer :: Type
+//. const Integer = ...;
+//.
+//. //    NonZeroInteger :: Type
+//. const NonZeroInteger = ...;
+//.
+//. //    env :: Array Type
+//. const env = $.env.concat([Integer, NonZeroInteger]);
+//. ```
+//.
+//. The next step is to define a `def` function for the environment:
+//.
+//. ```javascript
+//. const def = $.create({checkTypes: true, env: env});
+//. ```
+//.
+//. The `checkTypes` option determines whether type checking is enabled.
+//. This allows one to only pay the performance cost of run-time type checking
+//. during development. For example:
+//.
+//. ```javascript
+//. const def = $.create({
+//.   checkTypes: process.env.NODE_ENV === 'development',
+//.   env: env,
+//. });
+//. ```
+//.
+//. `def` is a function for defining functions. For example:
+//.
+//. ```javascript
+//. //    add :: Number -> Number -> Number
+//. const add =
+//. def('add', {}, [$.Number, $.Number, $.Number], (x, y) => x + y);
+//. ```
+//.
+//. `[$.Number, $.Number, $.Number]` specifies that `add` takes two arguments
+//. of type `Number` and returns a value of type `Number`.
+//.
+//. Applying `add` to two arguments gives the expected result:
+//.
+//. ```javascript
+//. add(2, 2);
+//. // => 4
+//. ```
+//.
+//. Applying `add` to greater than two arguments results in an exception being
+//. thrown:
+//.
+//. ```javascript
+//. add(2, 2, 2);
+//. // ! TypeError: ‘add’ requires two arguments; received three arguments
+//. ```
+//.
+//. Applying `add` to fewer than two arguments results in a function
+//. awaiting the remaining arguments. This is known as partial application.
+//. Partial application is convenient as it allows more specific functions
+//. to be defined in terms of more general ones:
+//.
+//. ```javascript
+//. //    inc :: Number -> Number
+//. const inc = add(1);
+//.
+//. inc(7);
+//. // => 8
+//. ```
+//.
+//. JavaScript's implicit type coercion often obfuscates the source of type
+//. errors. Consider the following function:
+//.
+//. ```javascript
+//. //    _add :: (Number, Number) -> Number
+//. const _add = (x, y) => x + y;
+//. ```
+//.
+//. The type signature indicates that `_add` takes two arguments of type
+//. `Number`, but this is not enforced. This allows type errors to be silently
+//. ignored:
+//.
+//. ```javascript
+//. _add('2', '2');
+//. // => '22'
+//. ```
+//.
+//. `add`, on the other hand, throws if applied to arguments of the wrong
+//. types:
+//.
+//. ```javascript
+//. add('2', '2');
+//. // ! TypeError: Invalid value
+//. //
+//. //   add :: Number -> Number -> Number
+//. //          ^^^^^^
+//. //            1
+//. //
+//. //   1)  "2" :: String
+//. //
+//. //   The value at position 1 is not a member of ‘Number’.
+//. ```
+//.
+//. Type checking is performed as arguments are provided (rather than once all
+//. arguments have been provided), so type errors are reported early:
+//.
+//. ```javascript
+//. add('X');
+//. // ! TypeError: Invalid value
+//. //
+//. //   add :: Number -> Number -> Number
+//. //          ^^^^^^
+//. //            1
+//. //
+//. //   1)  "X" :: String
+//. //
+//. //   The value at position 1 is not a member of ‘Number’.
+//. ```
+
 (function(f) {
 
   'use strict';
@@ -15,7 +159,28 @@
 
   'use strict';
 
-  var $ = {__: {'@@functional/placeholder': true}};
+  var $ = {};
+
+  //# __ :: Placeholder
+  //.
+  //. The special placeholder value.
+  //.
+  //. One may wish to partially apply a function whose parameters are in the
+  //. "wrong" order. Functions defined via sanctuary-def accommodate this by
+  //. accepting placeholders for arguments yet to be provided. For example:
+  //.
+  //. ```javascript
+  //. //    concatS :: String -> String -> String
+  //. const concatS =
+  //. def('concatS', {}, [$.String, $.String, $.String], (x, y) => x + y);
+  //.
+  //. //    exclaim :: String -> String
+  //. const exclaim = concatS($.__, '!');
+  //.
+  //. exclaim('ahoy');
+  //. // => 'ahoy!'
+  //. ```
+  $.__ = {'@@functional/placeholder': true};
 
   var MAX_SAFE_INTEGER = Math.pow(2, 53) - 1;
   var MIN_SAFE_INTEGER = -MAX_SAFE_INTEGER;
@@ -187,98 +352,9 @@
   var UNKNOWN       = 'UNKNOWN';
   var VARIABLE      = 'VARIABLE';
 
-  //  Unknown :: Type
-  var Unknown = $.Unknown =
-  createType(UNKNOWN, '', always2('???'), K(true), [], {});
-
   //  Inconsistent :: Type
   var Inconsistent =
   createType(INCONSISTENT, '', always2('???'), K(false), [], {});
-
-  //  TypeVariable :: String -> Type
-  $.TypeVariable = function(name) {
-    return createType(VARIABLE, name, always2(name), K(true), [], {});
-  };
-
-  //  UnaryTypeVariable :: String -> Type -> Type
-  $.UnaryTypeVariable = function(name) {
-    return function($1) {
-      var format = function(outer, inner) {
-        return outer('(' + name + ' ') + inner('$1')(String($1)) + outer(')');
-      };
-      var types = {$1: {extractor: K([]), type: $1}};
-      return createType(VARIABLE, name, format, K(true), ['$1'], types);
-    };
-  };
-
-  //  BinaryTypeVariable :: String -> ((Type, Type) -> Type)
-  $.BinaryTypeVariable = function(name) {
-    return function($1, $2) {
-      var format = function(outer, inner) {
-        return outer('(' + name + ' ') + inner('$1')(String($1)) + outer(' ') +
-                                         inner('$2')(String($2)) + outer(')');
-      };
-      var types = {$1: {extractor: K([]), type: $1},
-                   $2: {extractor: K([]), type: $2}};
-      return createType(VARIABLE, name, format, K(true), ['$1', '$2'], types);
-    };
-  };
-
-  //  NullaryType :: (String, (x -> Boolean)) -> Type
-  var NullaryType = $.NullaryType = function(name, test) {
-    var format = function(outer, inner) {
-      return outer(stripNamespace(name));
-    };
-    return createType(NULLARY, name, format, test, [], {});
-  };
-
-  //  UnaryType :: (String, (x -> Boolean), (t a -> Array a)) -> Type -> Type
-  var UnaryType = $.UnaryType = function(name, test, _1) {
-    return function($1) {
-      var format = function(outer, inner) {
-        return outer('(' + stripNamespace(name) + ' ') +
-               inner('$1')(String($1)) + outer(')');
-      };
-      var types = {$1: {extractor: _1, type: $1}};
-      return createType(UNARY, name, format, test, ['$1'], types);
-    };
-  };
-
-  //  UnaryType.from :: Type -> (Type -> Type)
-  UnaryType.from = function(t) {
-    return UnaryType(t.name, t._test, t.types.$1.extractor);
-  };
-
-  //  BinaryType ::
-  //    (String, (x -> Boolean), (t a b -> Array a), (t a b -> Array b)) ->
-  //      (Type, Type) -> Type
-  var BinaryType = $.BinaryType = function(name, test, _1, _2) {
-    return function($1, $2) {
-      var format = function(outer, inner) {
-        return outer('(' + stripNamespace(name) + ' ') +
-               inner('$1')(String($1)) + outer(' ') +
-               inner('$2')(String($2)) + outer(')');
-      };
-      var types = {$1: {extractor: _1, type: $1},
-                   $2: {extractor: _2, type: $2}};
-      return createType(BINARY, name, format, test, ['$1', '$2'], types);
-    };
-  };
-
-  //  BinaryType.xprod :: (Type, Array Type, Array Type) -> Array Type
-  BinaryType.xprod = function(t, $1s, $2s) {
-    var specialize = BinaryType(t.name,
-                                t._test,
-                                t.types.$1.extractor,
-                                t.types.$2.extractor);
-    var $types = [];
-    $1s.forEach(function($1) {
-      $2s.forEach(function($2) {
-        $types.push(specialize($1, $2));
-      });
-    });
-    return $types;
-  };
 
   //  $$type :: a -> String
   var $$type = function(x) {
@@ -304,66 +380,75 @@
     return UnaryType(name, $$typeEq(name), _1);
   };
 
-  //  EnumType :: Array Any -> Type
-  var EnumType = $.EnumType = function(members) {
-    var format = function(outer, inner) {
-      return outer('(' + Z.map(Z.toString, members).join(' | ') + ')');
-    };
-
-    var test = function(x) {
-      return members.some(function(member) { return Z.equals(x, member); });
-    };
-
-    return createType(ENUM, '', format, test, [], {});
+  //  applyParameterizedTypes :: Array Type -> Array Type
+  var applyParameterizedTypes = function(types) {
+    return Z.map(function(x) {
+      return typeof x === 'function' ?
+        x.apply(null, Z.map(K($.Unknown), range(0, x.length))) :
+        x;
+    }, types);
   };
 
-  //  RecordType :: StrMap Type -> Type
-  var RecordType = $.RecordType = function(fields) {
-    var keys = Object.keys(fields).sort();
+  //. ### Types
+  //.
+  //. Conceptually, a type is a set of values. One can think of a value of
+  //. type `Type` as a function of type `Any -> Boolean` which tests values
+  //. for membership in the set (though this is an oversimplification).
 
-    var invalidFieldNames = keys.filter(function(k) {
-      return $$type(fields[k]) !== 'sanctuary-def/Type';
-    });
-    if (!isEmpty(invalidFieldNames)) {
-      throw new TypeError(trimTrailingSpaces(
-        'Invalid values\n\n' +
-        'The argument to ‘RecordType’ must be an object ' +
-          'mapping field name to type.\n\n' +
-        'The following mappings are invalid:\n\n' +
-        Z.reduce(function(s, k) {
-          var v = fields[k];
-          return s + '  - ' + Z.toString(k) + ': ' + Z.toString(v) + '\n';
-        }, '', invalidFieldNames)
-      ));
-    }
+  //# Any :: Type
+  //.
+  //. Type comprising every JavaScript value.
+  $.Any = NullaryType('sanctuary-def/Any', K(true));
 
-    var format = function(outer, inner) {
-      return wrap(outer('{'))(outer(' }'))(Z.map(function(k) {
-        var t = fields[k];
-        return outer(' ' + k + ' :: ') +
-               unless(t.type === RECORD || isEmpty(t.keys),
-                      stripOutermostParens,
-                      inner(k)(String(t)));
-      }, keys).join(outer(',')));
-    };
+  //# AnyFunction :: Type
+  //.
+  //. Type comprising every Function value.
+  $.AnyFunction = type0('Function');
 
-    var test = function(x) {
-      return x != null &&
-             keys.every(function(k) { return hasOwnProperty.call(x, k); });
-    };
+  //# Arguments :: Type
+  //.
+  //. Type comprising every [`arguments`][arguments] object.
+  $.Arguments = type0('Arguments');
 
-    var $types = {};
-    keys.forEach(function(k) {
-      $types[k] = {extractor: function(x) { return [x[k]]; }, type: fields[k]};
-    });
+  //# Array :: Type -> Type
+  //.
+  //. Constructor for homogeneous Array types.
+  $.Array = type1('Array', id);
 
-    return createType(RECORD, '', format, test, keys, $types);
-  };
+  //# Boolean :: Type
+  //.
+  //. Type comprising `true` and `false` (and their object counterparts).
+  $.Boolean = type0('Boolean');
 
-  //  AnyFunction :: Type
-  var AnyFunction = type0('Function');
+  //# Date :: Type
+  //.
+  //. Type comprising every Date value.
+  $.Date = type0('Date');
 
-  //  $.Function :: Array Type -> Type
+  //# Error :: Type
+  //.
+  //. Type comprising every Error value, including values of more specific
+  //. constructors such as [`SyntaxError`][] and [`TypeError`][].
+  $.Error = type0('Error');
+
+  //# FiniteNumber :: Type
+  //.
+  //. Type comprising every [`ValidNumber`][] value except `Infinity` and
+  //. `-Infinity` (and their object counterparts).
+  $.FiniteNumber = NullaryType(
+    'sanctuary-def/FiniteNumber',
+    function(x) { return $.ValidNumber._test(x) && isFinite(x); }
+  );
+
+  //# Function :: Array Type -> Type
+  //.
+  //. Constructor for Function types.
+  //.
+  //. Examples:
+  //.
+  //.   - `$.Function([$.Date, $.String])` represents the `Date -> String`
+  //.     type; and
+  //.   - `$.Function([a, b, a])` represents the `(a, b) -> a` type.
   $.Function = function(types) {
     var format = function(outer, inner) {
       var xs = types.map(function(t, idx) {
@@ -379,6 +464,8 @@
                           last(xs));
     };
 
+    var test = $.AnyFunction._test;
+
     var $keys = [];
     var $types = {};
     types.forEach(function(t, idx) {
@@ -387,18 +474,170 @@
       $types[k] = {extractor: K([]), type: t};
     });
 
-    return createType(FUNCTION, '', format, AnyFunction._test, $keys, $types);
+    return createType(FUNCTION, '', format, test, $keys, $types);
   };
 
-  //  Nullable :: Type -> Type
+  //# Integer :: Type
+  //.
+  //. Type comprising every integer in the range
+  //. [[`Number.MIN_SAFE_INTEGER`][min] .. [`Number.MAX_SAFE_INTEGER`][max]].
+  $.Integer = NullaryType(
+    'sanctuary-def/Integer',
+    function(x) {
+      return $.ValidNumber._test(x) &&
+             Math.floor(x) == x &&  // eslint-disable-line eqeqeq
+             x >= MIN_SAFE_INTEGER &&
+             x <= MAX_SAFE_INTEGER;
+    }
+  );
+
+  //# NegativeFiniteNumber :: Type
+  //.
+  //. Type comprising every [`FiniteNumber`][] value less than zero.
+  $.NegativeFiniteNumber = NullaryType(
+    'sanctuary-def/NegativeFiniteNumber',
+    function(x) { return $.FiniteNumber._test(x) && x < 0; }
+  );
+
+  //# NegativeInteger :: Type
+  //.
+  //. Type comprising every [`Integer`][] value less than zero.
+  $.NegativeInteger = NullaryType(
+    'sanctuary-def/NegativeInteger',
+    function(x) { return $.Integer._test(x) && x < 0; }
+  );
+
+  //# NegativeNumber :: Type
+  //.
+  //. Type comprising every [`Number`][] value less than zero.
+  $.NegativeNumber = NullaryType(
+    'sanctuary-def/NegativeNumber',
+    function(x) { return $.Number._test(x) && x < 0; }
+  );
+
+  //# NonZeroFiniteNumber :: Type
+  //.
+  //. Type comprising every [`FiniteNumber`][] value except `0` and `-0`
+  //. (and their object counterparts).
+  $.NonZeroFiniteNumber = NullaryType(
+    'sanctuary-def/NonZeroFiniteNumber',
+    function(x) {
+      return $.FiniteNumber._test(x) && x != 0;  // eslint-disable-line eqeqeq
+    }
+  );
+
+  //# NonZeroInteger :: Type
+  //.
+  //. Type comprising every non-zero [`Integer`][] value.
+  $.NonZeroInteger = NullaryType(
+    'sanctuary-def/NonZeroInteger',
+    function(x) {
+      return $.Integer._test(x) && x != 0;  // eslint-disable-line eqeqeq
+    }
+  );
+
+  //# NonZeroValidNumber :: Type
+  //.
+  //. Type comprising every [`ValidNumber`][] value except `0` and `-0`
+  //. (and their object counterparts).
+  $.NonZeroValidNumber = NullaryType(
+    'sanctuary-def/NonZeroValidNumber',
+    function(x) {
+      return $.ValidNumber._test(x) && x != 0;  // eslint-disable-line eqeqeq
+    }
+  );
+
+  //# Null :: Type
+  //.
+  //. Type whose sole member is `null`.
+  $.Null = type0('Null');
+
+  //# Nullable :: Type -> Type
+  //.
+  //. Constructor for types which include `null` as a member.
   $.Nullable = UnaryType(
     'sanctuary-def/Nullable',
     K(true),
     function(nullable) { return nullable === null ? [] : [nullable]; }
   );
 
-  //  StrMap :: Type -> Type
-  var StrMap = UnaryType(
+  //# Number :: Type
+  //.
+  //. Type comprising every Number value (including `NaN` and Number objects).
+  $.Number = type0('Number');
+
+  //# Object :: Type
+  //.
+  //. Type comprising every "plain" Object value. Specifically, values
+  //. created via:
+  //.
+  //.   - object literal syntax;
+  //.   - [`Object.create`][]; or
+  //.   - the `new` operator in conjunction with `Object` or a custom
+  //.     constructor function.
+  $.Object = type0('Object');
+
+  //# Pair :: (Type, Type) -> Type
+  //.
+  //. Constructor for tuple types of length 2. Arrays are said to represent
+  //. tuples. `['foo', 42]` is a member of `Pair String Number`.
+  $.Pair = BinaryType(
+    'sanctuary-def/Pair',
+    function(x) { return $$typeEq('Array')(x) && x.length === 2; },
+    function(pair) { return [pair[0]]; },
+    function(pair) { return [pair[1]]; }
+  );
+
+  //# PositiveFiniteNumber :: Type
+  //.
+  //. Type comprising every [`FiniteNumber`][] value greater than zero.
+  $.PositiveFiniteNumber = NullaryType(
+    'sanctuary-def/PositiveFiniteNumber',
+    function(x) { return $.FiniteNumber._test(x) && x > 0; }
+  );
+
+  //# PositiveInteger :: Type
+  //.
+  //. Type comprising every [`Integer`][] value greater than zero.
+  $.PositiveInteger = NullaryType(
+    'sanctuary-def/PositiveInteger',
+    function(x) { return $.Integer._test(x) && x > 0; }
+  );
+
+  //# PositiveNumber :: Type
+  //.
+  //. Type comprising every [`Number`][] value greater than zero.
+  $.PositiveNumber = NullaryType(
+    'sanctuary-def/PositiveNumber',
+    function(x) { return $.Number._test(x) && x > 0; }
+  );
+
+  //# RegExp :: Type
+  //.
+  //. Type comprising every RegExp value.
+  $.RegExp = type0('RegExp');
+
+  //# RegexFlags :: Type
+  //.
+  //. Type comprising the canonical RegExp flags:
+  //.
+  //.   - `''`
+  //.   - `'g'`
+  //.   - `'i'`
+  //.   - `'m'`
+  //.   - `'gi'`
+  //.   - `'gm'`
+  //.   - `'im'`
+  //.   - `'gim'`
+  $.RegexFlags = EnumType(['', 'g', 'i', 'm', 'gi', 'gm', 'im', 'gim']);
+
+  //# StrMap :: Type -> Type
+  //.
+  //. Constructor for homogeneous Object types.
+  //.
+  //. `{foo: 1, bar: 2, baz: 3}`, for example, is a member of `StrMap Number`;
+  //. `{foo: 1, bar: 2, baz: 'XXX'}` is not.
+  $.StrMap = UnaryType(
     'sanctuary-def/StrMap',
     function(x) { return $.Object._test(x); },
     function(strMap) {
@@ -407,148 +646,72 @@
     }
   );
 
-  //  applyParameterizedTypes :: Array Type -> Array Type
-  var applyParameterizedTypes = function(types) {
-    return Z.map(function(x) {
-      return typeof x === 'function' ?
-        x.apply(null, Z.map(K(Unknown), range(0, x.length))) :
-        x;
-    }, types);
-  };
+  //# String :: Type
+  //.
+  //. Type comprising every String value (including String objects).
+  $.String = type0('String');
 
-  //  defaultEnv :: Array Type
-  var defaultEnv = $.env = applyParameterizedTypes([
-    $.AnyFunction = AnyFunction,
-    $.Arguments   = type0('Arguments'),
-    $.Array       = type1('Array', id),
-    $.Boolean     = type0('Boolean'),
-    $.Date        = type0('Date'),
-    $.Error       = type0('Error'),
-    $.Null        = type0('Null'),
-    $.Number      = type0('Number'),
-    $.Object      = type0('Object'),
-    $.RegExp      = type0('RegExp'),
-    $.StrMap      = StrMap,
-    $.String      = type0('String'),
-    $.Undefined   = type0('Undefined')
-  ]);
+  //# Undefined :: Type
+  //.
+  //. Type whose sole member is `undefined`.
+  $.Undefined = type0('Undefined');
 
-  //  Any :: Type
-  $.Any = NullaryType(
-    'sanctuary-def/Any',
-    K(true)
-  );
+  //# Unknown :: Type
+  //.
+  //. Type used internally to represent missing type information. The type of
+  //. `[]`, for example, is `Array ???`. This type is exported solely for use
+  //. by other Sanctuary packages.
+  $.Unknown = createType(UNKNOWN, '', always2('???'), K(true), [], {});
 
-  //  Pair :: (Type, Type) -> Type
-  $.Pair = BinaryType(
-    'sanctuary-def/Pair',
-    function(x) { return $$typeEq('Array')(x) && x.length === 2; },
-    function(pair) { return [pair[0]]; },
-    function(pair) { return [pair[1]]; }
-  );
-
-  //  ValidDate :: Type
+  //# ValidDate :: Type
+  //.
+  //. Type comprising every [`Date`][] value except `new Date(NaN)`.
   $.ValidDate = NullaryType(
     'sanctuary-def/ValidDate',
     function(x) { return $.Date._test(x) && !isNaN(x.valueOf()); }
   );
 
-  //  PositiveNumber :: Type
-  $.PositiveNumber = NullaryType(
-    'sanctuary-def/PositiveNumber',
-    function(x) { return $.Number._test(x) && x > 0; }
-  );
-
-  //  NegativeNumber :: Type
-  $.NegativeNumber = NullaryType(
-    'sanctuary-def/NegativeNumber',
-    function(x) { return $.Number._test(x) && x < 0; }
-  );
-
-  //  ValidNumber :: Type
-  var ValidNumber = $.ValidNumber = NullaryType(
+  //# ValidNumber :: Type
+  //.
+  //. Type comprising every [`Number`][] value except `NaN` (and its object
+  //. counterpart).
+  $.ValidNumber = NullaryType(
     'sanctuary-def/ValidNumber',
     function(x) { return $.Number._test(x) && !isNaN(x); }
   );
 
-  //  NonZeroValidNumber :: Type
-  $.NonZeroValidNumber = NullaryType(
-    'sanctuary-def/NonZeroValidNumber',
-    function(x) {
-      return ValidNumber._test(x) &&
-             /* eslint-disable eqeqeq */
-             x != 0;
-             /* eslint-enable eqeqeq */
-    }
-  );
-
-  //  FiniteNumber :: Type
-  var FiniteNumber = $.FiniteNumber = NullaryType(
-    'sanctuary-def/FiniteNumber',
-    function(x) { return ValidNumber._test(x) && isFinite(x); }
-  );
-
-  //  PositiveFiniteNumber :: Type
-  $.PositiveFiniteNumber = NullaryType(
-    'sanctuary-def/PositiveFiniteNumber',
-    function(x) { return FiniteNumber._test(x) && x > 0; }
-  );
-
-  //  NegativeFiniteNumber :: Type
-  $.NegativeFiniteNumber = NullaryType(
-    'sanctuary-def/NegativeFiniteNumber',
-    function(x) { return FiniteNumber._test(x) && x < 0; }
-  );
-
-  //  NonZeroFiniteNumber :: Type
-  $.NonZeroFiniteNumber = NullaryType(
-    'sanctuary-def/NonZeroFiniteNumber',
-    function(x) {
-      return FiniteNumber._test(x) &&
-             /* eslint-disable eqeqeq */
-             x != 0;
-             /* eslint-enable eqeqeq */
-    }
-  );
-
-  //  Integer :: Type
-  var Integer = $.Integer = NullaryType(
-    'sanctuary-def/Integer',
-    function(x) {
-      return ValidNumber._test(x) &&
-             /* eslint-disable eqeqeq */
-             Math.floor(x) == x &&
-             /* eslint-enable eqeqeq */
-             x >= MIN_SAFE_INTEGER &&
-             x <= MAX_SAFE_INTEGER;
-    }
-  );
-
-  //  PositiveInteger :: Type
-  $.PositiveInteger = NullaryType(
-    'sanctuary-def/PositiveInteger',
-    function(x) { return Integer._test(x) && x > 0; }
-  );
-
-  //  NegativeInteger :: Type
-  $.NegativeInteger = NullaryType(
-    'sanctuary-def/NegativeInteger',
-    function(x) { return Integer._test(x) && x < 0; }
-  );
-
-  //  NonZeroInteger :: Type
-  $.NonZeroInteger = NullaryType(
-    'sanctuary-def/NonZeroInteger',
-    function(x) {
-      return Integer._test(x) &&
-             /* eslint-disable eqeqeq */
-             x != 0;
-             /* eslint-enable eqeqeq */
-    }
-  );
-
-  //  RegexFlags :: Type
-  $.RegexFlags = EnumType(['', 'g', 'i', 'm', 'gi', 'gm', 'im', 'gim']);
+  //# env :: Array Type
+  //.
+  //. An array of [types][]:
+  //.
+  //.   - [`AnyFunction`][]
+  //.   - [`Arguments`][]
+  //.   - [`Array`][]
+  //.   - [`Boolean`][]
+  //.   - [`Date`][]
+  //.   - [`Error`][]
+  //.   - [`Null`][]
+  //.   - [`Number`][]
+  //.   - [`Object`][]
+  //.   - [`RegExp`][]
+  //.   - [`StrMap`][]
+  //.   - [`String`][]
+  //.   - [`Undefined`][]
+  $.env = applyParameterizedTypes([
+    $.AnyFunction,
+    $.Arguments,
+    $.Array,
+    $.Boolean,
+    $.Date,
+    $.Error,
+    $.Null,
+    $.Number,
+    $.Object,
+    $.RegExp,
+    $.StrMap,
+    $.String,
+    $.Undefined
+  ]);
 
   //  Type :: Type
   var Type = type0('sanctuary-def/Type');
@@ -632,7 +795,7 @@
       if (typeof value === 'object' && value != null ||
           typeof value === 'function') {
         //  Abort if a circular reference is encountered; add the current
-        //  object to the list of seen objects otherwise.
+        //  object to the array of seen objects otherwise.
         if (seen.indexOf(value) >= 0) return [];
         seen$ = Z.concat(seen, [value]);
       } else {
@@ -643,10 +806,10 @@
           t.name === 'sanctuary-def/Nullable' || !t._test(value) ?
             [] :
           t.type === UNARY ?
-            Z.map(UnaryType.from(t),
+            Z.map(fromUnaryType(t),
                   recur(loose, env, env, seen$, t.types.$1.extractor(value))) :
           t.type === BINARY ?
-            BinaryType.xprod(
+            xprod(
               t,
               t.types.$1.type.type === UNKNOWN ?
                 recur(loose, env, env, seen$, t.types.$1.extractor(value)) :
@@ -662,7 +825,7 @@
     };
 
     return isEmpty(values) ?
-      [Unknown] :
+      [$.Unknown] :
       or(Z.reduce(refine, types, values), loose ? [Inconsistent] : []);
   };
 
@@ -728,7 +891,7 @@
       $typeVarMap[typeVar.name].types = Z.chain(
         function(t) {
           var xs;
-          var invalid = !test(env, t, value);
+          var invalid = !$.test(env, t, value);
           return (
             invalid ?
               [] :
@@ -747,21 +910,19 @@
             t.type === UNARY ?
               t.types.$1.type.type === UNKNOWN &&
               !isEmpty(xs = t.types.$1.extractor(value)) ?
-                Z.map(UnaryType.from(t),
+                Z.map(fromUnaryType(t),
                       determineActualTypesStrict(env, env, xs)) :
                 [t] :
             t.type === BINARY ?
-              BinaryType.xprod(
-                t,
-                t.types.$1.type.type === UNKNOWN &&
-                !isEmpty(xs = t.types.$1.extractor(value)) ?
-                  determineActualTypesStrict(env, env, xs) :
-                  [t.types.$1.type],
-                t.types.$2.type.type === UNKNOWN &&
-                !isEmpty(xs = t.types.$2.extractor(value)) ?
-                  determineActualTypesStrict(env, env, xs) :
-                  [t.types.$2.type]
-              ) :
+              xprod(t,
+                    t.types.$1.type.type === UNKNOWN &&
+                    !isEmpty(xs = t.types.$1.extractor(value)) ?
+                      determineActualTypesStrict(env, env, xs) :
+                      [t.types.$1.type],
+                    t.types.$2.type.type === UNKNOWN &&
+                    !isEmpty(xs = t.types.$2.extractor(value)) ?
+                      determineActualTypesStrict(env, env, xs) :
+                      [t.types.$2.type]) :
             // else
               [t]
           );
@@ -880,7 +1041,7 @@
                 var innerValues = Z.chain(t.types[k].extractor, values);
                 return Z.reduce(function(e, x) {
                   return Z.chain(function(r) {
-                    return $1.type === VARIABLE || test(env, $1, x) ?
+                    return $1.type === VARIABLE || $.test(env, $1, x) ?
                       Right(r) :
                       Left(function() {
                         return invalidValue(env,
@@ -899,7 +1060,7 @@
           function(result) {
             return {
               typeVarMap: result.typeVarMap,
-              types: Z.map(UnaryType.from(expType),
+              types: Z.map(fromUnaryType(expType),
                            or(result.types, [expType.types.$1.type]))
             };
           },
@@ -921,9 +1082,9 @@
                 var $2s = result.types;
                 return {
                   typeVarMap: result.typeVarMap,
-                  types: BinaryType.xprod(expType,
-                                          or($1s, [expType.types.$1.type]),
-                                          or($2s, [expType.types.$2.type]))
+                  types: xprod(expType,
+                               or($1s, [expType.types.$1.type]),
+                               or($2s, [expType.types.$2.type]))
                 };
               },
               recur(env,
@@ -962,12 +1123,679 @@
     }
   };
 
-  //  test :: (Array Type, Type, Any) -> Boolean
-  var test = $.test = function(_env, t, x) {
+  //# test :: (Array Type, Type, a) -> Boolean
+  //.
+  //. Takes an environment, a type, and any value. Returns `true` if the value
+  //. is a member of the type; `false` otherwise.
+  //.
+  //. The environment is only significant if the type contains
+  //. [type variables][].
+  //.
+  //. One may define a more restrictive type in terms of a more general one:
+  //.
+  //. ```javascript
+  //. //    NonNegativeInteger :: Type
+  //. const NonNegativeInteger = $.NullaryType(
+  //.   'my-package/NonNegativeInteger',
+  //.   x => $.test([], $.Integer, x) && x >= 0
+  //. );
+  //. ```
+  //.
+  //. Using types as predicates is useful in other contexts too. One could,
+  //. for example, define a [record type][] for each endpoint of a REST API
+  //. and validate the bodies of incoming POST requests against these types.
+  $.test = function(_env, t, x) {
     var env = applyParameterizedTypes(_env);
     var typeInfo = {name: 'name', constraints: {}, types: [t]};
     return satisfactoryTypes(env, typeInfo, {}, t, 0, [], [x]).isRight;
   };
+
+  //. ### Type constructors
+  //.
+  //. sanctuary-def provides several functions for defining types.
+
+  //# NullaryType :: (String, Any -> Boolean) -> Type
+  //.
+  //. Type constructor for types with no type variables (such as [`Number`][]).
+  //.
+  //. To define a nullary type `t` one must provide:
+  //.
+  //.   - the name of `t` (exposed as `t.name`); and
+  //.
+  //.   - a predicate which accepts any JavaScript value and returns `true` if
+  //.     (and only if) the value is a member of `t`.
+  //.
+  //. For example:
+  //.
+  //. ```javascript
+  //. //    Integer :: Type
+  //. const Integer = $.NullaryType(
+  //.   'my-package/Integer',
+  //.   x => Object.prototype.toString.call(x) === '[object Number]' &&
+  //.        Math.floor(x) === Number(x) &&
+  //.        x >= Number.MIN_SAFE_INTEGER &&
+  //.        x <= Number.MAX_SAFE_INTEGER
+  //. );
+  //.
+  //. //    NonZeroInteger :: Type
+  //. const NonZeroInteger = $.NullaryType(
+  //.   'my-package/NonZeroInteger',
+  //.   x => $.test([], Integer, x) && Number(x) !== 0
+  //. );
+  //.
+  //. //    rem :: Integer -> NonZeroInteger -> Integer
+  //. const rem =
+  //. def('rem', {}, [Integer, NonZeroInteger, Integer], (x, y) => x % y);
+  //.
+  //. rem(42, 5);
+  //. // => 2
+  //.
+  //. rem(0.5);
+  //. // ! TypeError: Invalid value
+  //. //
+  //. //   rem :: Integer -> NonZeroInteger -> Integer
+  //. //          ^^^^^^^
+  //. //             1
+  //. //
+  //. //   1)  0.5 :: Number
+  //. //
+  //. //   The value at position 1 is not a member of ‘Integer’.
+  //.
+  //. rem(42, 0);
+  //. // ! TypeError: Invalid value
+  //. //
+  //. //   rem :: Integer -> NonZeroInteger -> Integer
+  //. //                     ^^^^^^^^^^^^^^
+  //. //                           1
+  //. //
+  //. //   1)  0 :: Number
+  //. //
+  //. //   The value at position 1 is not a member of ‘NonZeroInteger’.
+  //. ```
+  function NullaryType(name, test) {
+    var format = function(outer, inner) {
+      return outer(stripNamespace(name));
+    };
+    return createType(NULLARY, name, format, test, [], {});
+  }
+  $.NullaryType = NullaryType;
+
+  //# UnaryType :: (String, Any -> Boolean, t a -> Array a) -> (Type -> Type)
+  //.
+  //. Type constructor for types with one type variable (such as [`Array`][]).
+  //.
+  //. To define a unary type `t a` one must provide:
+  //.
+  //.   - the name of `t` (exposed as `t.name`);
+  //.
+  //.   - a predicate which accepts any JavaScript value and returns `true`
+  //.     if (and only if) the value is a member of `t x` for some type `x`;
+  //.
+  //.   - a function which takes any value of type `t a` and returns an array
+  //.     of the values of type `a` contained in the `t` (exposed as
+  //.     `t.types.$1.extractor`); and
+  //.
+  //.   - the type of `a` (exposed as `t.types.$1.type`).
+  //.
+  //. For example:
+  //.
+  //. ```javascript
+  //. //    Maybe :: Type -> Type
+  //. const Maybe = $.UnaryType(
+  //.   'my-package/Maybe',
+  //.   x => x != null && x['@@type'] === 'my-package/Maybe',
+  //.   maybe => maybe.isJust ? [maybe.value] : []
+  //. );
+  //.
+  //. //    Nothing :: Maybe a
+  //. const Nothing = {
+  //.   '@@type': 'my-package/Maybe',
+  //.   isJust: false,
+  //.   isNothing: true,
+  //.   toString: () => 'Nothing',
+  //. };
+  //.
+  //. //    Just :: a -> Maybe a
+  //. const Just = x => ({
+  //.   '@@type': 'my-package/Maybe',
+  //.   isJust: true,
+  //.   isNothing: false,
+  //.   toString: () => 'Just(' + Z.toString(x) + ')',
+  //.   value: x,
+  //. });
+  //.
+  //. //    fromMaybe :: a -> Maybe a -> a
+  //. const fromMaybe =
+  //. def('fromMaybe', {}, [a, Maybe(a), a], (x, m) => m.isJust ? m.value : x);
+  //.
+  //. fromMaybe(0, Just(42));
+  //. // => 42
+  //.
+  //. fromMaybe(0, Nothing);
+  //. // => 0
+  //.
+  //. fromMaybe(0, Just('XXX'));
+  //. // ! TypeError: Type-variable constraint violation
+  //. //
+  //. //   fromMaybe :: a -> Maybe a -> a
+  //. //                ^          ^
+  //. //                1          2
+  //. //
+  //. //   1)  0 :: Number
+  //. //
+  //. //   2)  "XXX" :: String
+  //. //
+  //. //   Since there is no type of which all the above values are members, the type-variable constraint has been violated.
+  //. ```
+  function UnaryType(name, test, _1) {
+    return function($1) {
+      var format = function(outer, inner) {
+        return outer('(' + stripNamespace(name) + ' ') +
+               inner('$1')(String($1)) + outer(')');
+      };
+      var types = {$1: {extractor: _1, type: $1}};
+      return createType(UNARY, name, format, test, ['$1'], types);
+    };
+  }
+  $.UnaryType = UnaryType;
+
+  //  fromUnaryType :: Type -> (Type -> Type)
+  var fromUnaryType = function(t) {
+    return UnaryType(t.name, t._test, t.types.$1.extractor);
+  };
+
+  //# BinaryType :: (String, Any -> Boolean, t a b -> Array a, t a b -> Array b) -> ((Type, Type) -> Type)
+  //.
+  //. Type constructor for types with two type variables (such as [`Pair`][]).
+  //.
+  //. To define a binary type `t a b` one must provide:
+  //.
+  //.   - the name of `t` (exposed as `t.name`);
+  //.
+  //.   - a predicate which accepts any JavaScript value and returns `true`
+  //.     if (and only if) the value is a member of `t x y` for some types
+  //.     `x` and `y`;
+  //.
+  //.   - a function which takes any value of type `t a b` and returns an array
+  //.     of the values of type `a` contained in the `t` (exposed as
+  //.     `t.types.$1.extractor`);
+  //.
+  //.   - a function which takes any value of type `t a b` and returns an array
+  //.     of the values of type `b` contained in the `t` (exposed as
+  //.     `t.types.$2.extractor`);
+  //.
+  //.   - the type of `a` (exposed as `t.types.$1.type`); and
+  //.
+  //.   - the type of `b` (exposed as `t.types.$2.type`).
+  //.
+  //. For example:
+  //.
+  //. ```javascript
+  //. //    $Pair :: Type -> Type -> Type
+  //. const $Pair = $.BinaryType(
+  //.   'my-package/Pair',
+  //.   x => x != null && x['@@type'] === 'my-package/Pair',
+  //.   pair => [pair[0]],
+  //.   pair => [pair[1]]
+  //. );
+  //.
+  //. //    Pair :: a -> b -> Pair a b
+  //. const Pair = def('Pair', {}, [a, b, $Pair(a, b)], (x, y) => ({
+  //.   '0': x,
+  //.   '1': y,
+  //.   '@@type': 'my-package/Pair',
+  //.   length: 2,
+  //.   toString: () => 'Pair(' + Z.toString(x) + ', ' + Z.toString(y) + ')',
+  //. }));
+  //.
+  //. //    Rank :: Type
+  //. const Rank = $.NullaryType(
+  //.   'my-package/Rank',
+  //.   x => typeof x === 'string' && /^([A23456789JQK]|10)$/.test(x),
+  //.   'A'
+  //. );
+  //.
+  //. //    Suit :: Type
+  //. const Suit = $.NullaryType(
+  //.   'my-package/Suit',
+  //.   x => typeof x === 'string' && /^[\u2660\u2663\u2665\u2666]$/.test(x),
+  //.   '\u2660'
+  //. );
+  //.
+  //. //    Card :: Type
+  //. const Card = $Pair(Rank, Suit);
+  //.
+  //. //    showCard :: Card -> String
+  //. const showCard =
+  //. def('showCard', {}, [Card, $.String], card => card[0] + card[1]);
+  //.
+  //. showCard(Pair('A', '♠'));
+  //. // => 'A♠'
+  //.
+  //. showCard(Pair('X', '♠'));
+  //. // ! TypeError: Invalid value
+  //. //
+  //. //   showCard :: Pair Rank Suit -> String
+  //. //                    ^^^^
+  //. //                     1
+  //. //
+  //. //   1)  "X" :: String
+  //. //
+  //. //   The value at position 1 is not a member of ‘Rank’.
+  //. ```
+  function BinaryType(name, test, _1, _2) {
+    return function($1, $2) {
+      var format = function(outer, inner) {
+        return outer('(' + stripNamespace(name) + ' ') +
+               inner('$1')(String($1)) + outer(' ') +
+               inner('$2')(String($2)) + outer(')');
+      };
+      var types = {$1: {extractor: _1, type: $1},
+                   $2: {extractor: _2, type: $2}};
+      return createType(BINARY, name, format, test, ['$1', '$2'], types);
+    };
+  }
+  $.BinaryType = BinaryType;
+
+  //  xprod :: (Type, Array Type, Array Type) -> Array Type
+  var xprod = function(t, $1s, $2s) {
+    var specialize = BinaryType(t.name,
+                                t._test,
+                                t.types.$1.extractor,
+                                t.types.$2.extractor);
+    var $types = [];
+    $1s.forEach(function($1) {
+      $2s.forEach(function($2) {
+        $types.push(specialize($1, $2));
+      });
+    });
+    return $types;
+  };
+
+  //# EnumType :: Array Any -> Type
+  //.
+  //. `EnumType` is used to construct [enumerated types][].
+  //.
+  //. To define an enumerated type one must provide:
+  //.
+  //.   - an array of distinct values.
+  //.
+  //. For example:
+  //.
+  //. ```javascript
+  //. //    TimeUnit :: Type
+  //. const TimeUnit =
+  //. $.EnumType(['milliseconds', 'seconds', 'minutes', 'hours']);
+  //.
+  //. //    convertTo :: TimeUnit -> ValidDate -> ValidNumber
+  //. const convertTo =
+  //. def('convertTo',
+  //.     {},
+  //.     [TimeUnit, $.ValidDate, $.ValidNumber],
+  //.     function recur(unit, date) {
+  //.       switch (unit) {
+  //.         case 'milliseconds': return date.valueOf();
+  //.         case 'seconds':      return recur('milliseconds', date) / 1000;
+  //.         case 'minutes':      return recur('seconds', date) / 60;
+  //.         case 'hours':        return recur('minutes', date) / 60;
+  //.       }
+  //.     });
+  //.
+  //. convertTo('seconds', new Date(1000));
+  //. // => 1
+  //.
+  //. convertTo('days', new Date(1000));
+  //. // ! TypeError: Invalid value
+  //. //
+  //. //   convertTo :: ("milliseconds" | "seconds" | "minutes" | "hours") -> ValidDate -> ValidNumber
+  //. //                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  //. //                                        1
+  //. //
+  //. //   1)  "days" :: String
+  //. //
+  //. //   The value at position 1 is not a member of ‘("milliseconds" | "seconds" | "minutes" | "hours")’.
+  //. ```
+  function EnumType(members) {
+    var format = function(outer, inner) {
+      return outer('(' + Z.map(Z.toString, members).join(' | ') + ')');
+    };
+
+    var test = function(x) {
+      return members.some(function(member) { return Z.equals(x, member); });
+    };
+
+    return createType(ENUM, '', format, test, [], {});
+  }
+  $.EnumType = EnumType;
+
+  //# RecordType :: StrMap Type -> Type
+  //.
+  //. `RecordType` is used to construct record types. The type definition
+  //. specifies the name and type of each required field.
+  //.
+  //. To define a record type one must provide:
+  //.
+  //.   - an object mapping field name to type.
+  //.
+  //. For example:
+  //.
+  //. ```javascript
+  //. //    Point :: Type
+  //. const Point = $.RecordType({x: $.FiniteNumber, y: $.FiniteNumber});
+  //.
+  //. //    dist :: Point -> Point -> FiniteNumber
+  //. const dist =
+  //. def('dist', {}, [Point, Point, $.FiniteNumber],
+  //.     (p, q) => Math.sqrt(Math.pow(p.x - q.x, 2) +
+  //.                         Math.pow(p.y - q.y, 2)));
+  //.
+  //. dist({x: 0, y: 0}, {x: 3, y: 4});
+  //. // => 5
+  //.
+  //. dist({x: 0, y: 0}, {x: 3, y: 4, color: 'red'});
+  //. // => 5
+  //.
+  //. dist({x: 0, y: 0}, {x: NaN, y: NaN});
+  //. // ! TypeError: Invalid value
+  //. //
+  //. //   dist :: { x :: FiniteNumber, y :: FiniteNumber } -> { x :: FiniteNumber, y :: FiniteNumber } -> FiniteNumber
+  //. //                                                              ^^^^^^^^^^^^
+  //. //                                                                   1
+  //. //
+  //. //   1)  NaN :: Number
+  //. //
+  //. //   The value at position 1 is not a member of ‘FiniteNumber’.
+  //.
+  //. dist(0);
+  //. // ! TypeError: Invalid value
+  //. //
+  //. //   dist :: { x :: FiniteNumber, y :: FiniteNumber } -> { x :: FiniteNumber, y :: FiniteNumber } -> FiniteNumber
+  //. //           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  //. //                              1
+  //. //
+  //. //   1)  0 :: Number
+  //. //
+  //. //   The value at position 1 is not a member of ‘{ x :: FiniteNumber, y :: FiniteNumber }’.
+  //. ```
+  function RecordType(fields) {
+    var keys = Object.keys(fields).sort();
+
+    var invalidFieldNames = keys.filter(function(k) {
+      return $$type(fields[k]) !== 'sanctuary-def/Type';
+    });
+    if (!isEmpty(invalidFieldNames)) {
+      throw new TypeError(trimTrailingSpaces(
+        'Invalid values\n\n' +
+        'The argument to ‘RecordType’ must be an object ' +
+          'mapping field name to type.\n\n' +
+        'The following mappings are invalid:\n\n' +
+        Z.reduce(function(s, k) {
+          var v = fields[k];
+          return s + '  - ' + Z.toString(k) + ': ' + Z.toString(v) + '\n';
+        }, '', invalidFieldNames)
+      ));
+    }
+
+    var format = function(outer, inner) {
+      return wrap(outer('{'))(outer(' }'))(Z.map(function(k) {
+        var t = fields[k];
+        return outer(' ' + k + ' :: ') +
+               unless(t.type === RECORD || isEmpty(t.keys),
+                      stripOutermostParens,
+                      inner(k)(String(t)));
+      }, keys).join(outer(',')));
+    };
+
+    var test = function(x) {
+      return x != null &&
+             keys.every(function(k) { return hasOwnProperty.call(x, k); });
+    };
+
+    var $types = {};
+    keys.forEach(function(k) {
+      $types[k] = {extractor: function(x) { return [x[k]]; }, type: fields[k]};
+    });
+
+    return createType(RECORD, '', format, test, keys, $types);
+  }
+  $.RecordType = RecordType;
+
+  //# TypeVariable :: String -> Type
+  //.
+  //. Polymorphism is powerful. Not being able to define a function for
+  //. all types would be very limiting indeed: one couldn't even define the
+  //. identity function!
+  //.
+  //. Before defining a polymorphic function one must define one or more type
+  //. variables:
+  //.
+  //. ```javascript
+  //. const a = $.TypeVariable('a');
+  //. const b = $.TypeVariable('b');
+  //.
+  //. //    id :: a -> a
+  //. const id = def('id', {}, [a, a], x => x);
+  //.
+  //. id(42);
+  //. // => 42
+  //.
+  //. id(null);
+  //. // => null
+  //. ```
+  //.
+  //. The same type variable may be used in multiple positions, creating a
+  //. constraint:
+  //.
+  //. ```javascript
+  //. //    cmp :: a -> a -> Number
+  //. const cmp =
+  //. def('cmp', {}, [a, a, $.Number], (x, y) => x < y ? -1 : x > y ? 1 : 0);
+  //.
+  //. cmp(42, 42);
+  //. // => 0
+  //.
+  //. cmp('a', 'z');
+  //. // => -1
+  //.
+  //. cmp('z', 'a');
+  //. // => 1
+  //.
+  //. cmp(0, '1');
+  //. // ! TypeError: Type-variable constraint violation
+  //. //
+  //. //   cmp :: a -> a -> Number
+  //. //          ^    ^
+  //. //          1    2
+  //. //
+  //. //   1)  0 :: Number
+  //. //
+  //. //   2)  "1" :: String
+  //. //
+  //. //   Since there is no type of which all the above values are members, the type-variable constraint has been violated.
+  //. ```
+  function TypeVariable(name) {
+    return createType(VARIABLE, name, always2(name), K(true), [], {});
+  }
+  $.TypeVariable = TypeVariable;
+
+  //# UnaryTypeVariable :: String -> (Type -> Type)
+  //.
+  //. Combines [`UnaryType`][] and [`TypeVariable`][].
+  //.
+  //. To define a unary type variable `t a` one must provide:
+  //.
+  //.   - a name (conventionally matching `^[a-z]$`); and
+  //.
+  //.   - the type of `a` (exposed as `t.types.$1.type`).
+  //.
+  //. Consider the type of a generalized `map`:
+  //.
+  //. ```haskell
+  //. map :: Functor f => (a -> b) -> f a -> f b
+  //. ```
+  //.
+  //. `f` is a unary type variable. With two (nullary) type variables, one
+  //. unary type variable, and one [type class][] it's possible to define a
+  //. fully polymorphic `map` function:
+  //.
+  //. ```javascript
+  //. const $ = require('sanctuary-def');
+  //. const Z = require('sanctuary-type-classes');
+  //.
+  //. const a = $.TypeVariable('a');
+  //. const b = $.TypeVariable('b');
+  //. const f = $.UnaryTypeVariable('f');
+  //.
+  //. //    map :: Functor f => (a -> b) -> f a -> f b
+  //. const map =
+  //. def('map',
+  //.     {f: [Z.Functor]},
+  //.     [$.Function([a, b]), f(a), f(b)],
+  //.     Z.map);
+  //. ```
+  //.
+  //. Whereas a regular type variable is fully resolved (`a` might become
+  //. `Array (Array String)`, for example), a unary type variable defers to
+  //. its type argument, which may itself be a type variable. The type argument
+  //. corresponds to the type argument of a unary type or the *second* type
+  //. argument of a binary type. The second type argument of `Map k v`, for
+  //. example, is `v`. One could replace `Functor => f` with `Map k` or with
+  //. `Map Integer`, but not with `Map`.
+  //.
+  //. This shallow inspection makes it possible to constrain a value's "outer"
+  //. and "inner" types independently.
+  function UnaryTypeVariable(name) {
+    return function($1) {
+      var format = function(outer, inner) {
+        return outer('(' + name + ' ') + inner('$1')(String($1)) + outer(')');
+      };
+      var types = {$1: {extractor: K([]), type: $1}};
+      return createType(VARIABLE, name, format, K(true), ['$1'], types);
+    };
+  }
+  $.UnaryTypeVariable = UnaryTypeVariable;
+
+  //# BinaryTypeVariable :: String -> ((Type, Type) -> Type)
+  //.
+  //. Combines [`BinaryType`][] and [`TypeVariable`][].
+  //.
+  //. To define a binary type variable `t a b` one must provide:
+  //.
+  //.   - a name (conventionally matching `^[a-z]$`);
+  //.
+  //.   - the type of `a` (exposed as `t.types.$1.type`); and
+  //.
+  //.   - the type of `b` (exposed as `t.types.$2.type`).
+  //.
+  //. The more detailed explanation of [`UnaryTypeVariable`][] also applies to
+  //. `BinaryTypeVariable`.
+  function BinaryTypeVariable(name) {
+    return function($1, $2) {
+      var format = function(outer, inner) {
+        return outer('(' + name + ' ') + inner('$1')(String($1)) + outer(' ') +
+                                         inner('$2')(String($2)) + outer(')');
+      };
+      var types = {$1: {extractor: K([]), type: $1},
+                   $2: {extractor: K([]), type: $2}};
+      return createType(VARIABLE, name, format, K(true), ['$1', '$2'], types);
+    };
+  }
+  $.BinaryTypeVariable = BinaryTypeVariable;
+
+  //. ### Type classes
+  //.
+  //. `concatS`, defined earlier, is a function which concatenates two strings.
+  //. This is overly restrictive, since other types support concatenation
+  //. (Array, for example).
+  //.
+  //. One could use a type variable to define a polymorphic "concat" function:
+  //.
+  //. ```javascript
+  //. //    _concat :: a -> a -> a
+  //. const _concat =
+  //. def('_concat', {}, [a, a, a], (x, y) => x.concat(y));
+  //.
+  //. _concat('fizz', 'buzz');
+  //. // => 'fizzbuzz'
+  //.
+  //. _concat([1, 2], [3, 4]);
+  //. // => [1, 2, 3, 4]
+  //.
+  //. _concat([1, 2], 'buzz');
+  //. // ! TypeError: Type-variable constraint violation
+  //. //
+  //. //   _concat :: a -> a -> a
+  //. //              ^    ^
+  //. //              1    2
+  //. //
+  //. //   1)  [1, 2] :: Array Number
+  //. //
+  //. //   2)  "buzz" :: String
+  //. //
+  //. //   Since there is no type of which all the above values are members, the type-variable constraint has been violated.
+  //. ```
+  //.
+  //. The type of `_concat` is misleading: it suggests that it can operate on
+  //. any two values of *any* one type. In fact there's an implicit constraint,
+  //. since the type must support concatenation (in [mathematical][semigroup]
+  //. terms, the type must have a [semigroup][FL:Semigroup]). The run-time type
+  //. errors that result when this constraint is violated are not particularly
+  //. descriptive:
+  //.
+  //. ```javascript
+  //. _concat({}, {});
+  //. // ! TypeError: undefined is not a function
+  //.
+  //. _concat(null, null);
+  //. // ! TypeError: Cannot read property 'concat' of null
+  //. ```
+  //.
+  //. The solution is to constrain `a` by first defining a [`TypeClass`][]
+  //. value, then specifying the constraint in the definition of the "concat"
+  //. function:
+  //.
+  //. ```javascript
+  //. const Z = require('sanctuary-type-classes');
+  //.
+  //. //    Semigroup :: TypeClass
+  //. const Semigroup = Z.TypeClass(
+  //.   'my-package/Semigroup',
+  //.   [],
+  //.   x => x != null && typeof x.concat === 'function'
+  //. );
+  //.
+  //. //    concat :: Semigroup a => a -> a -> a
+  //. const concat =
+  //. def('concat', {a: [Semigroup]}, [a, a, a], (x, y) => x.concat(y));
+  //.
+  //. concat([1, 2], [3, 4]);
+  //. // => [1, 2, 3, 4]
+  //.
+  //. concat({}, {});
+  //. // ! TypeError: Type-class constraint violation
+  //. //
+  //. //   concat :: Semigroup a => a -> a -> a
+  //. //             ^^^^^^^^^^^    ^
+  //. //                            1
+  //. //
+  //. //   1)  {} :: Object, StrMap ???
+  //. //
+  //. //   ‘concat’ requires ‘a’ to satisfy the Semigroup type-class constraint; the value at position 1 does not.
+  //.
+  //. concat(null, null);
+  //. // ! TypeError: Type-class constraint violation
+  //. //
+  //. //   concat :: Semigroup a => a -> a -> a
+  //. //             ^^^^^^^^^^^    ^
+  //. //                            1
+  //. //
+  //. //   1)  null :: Null
+  //. //
+  //. //   ‘concat’ requires ‘a’ to satisfy the Semigroup type-class constraint; the value at position 1 does not.
+  //. ```
+  //.
+  //. Multiple constraints may be placed on a type variable by including
+  //. multiple `TypeClass` values in the array (e.g. `{a: [Foo, Bar, Baz]}`).
 
   //  checkValue :: ... -> Undefined
   var checkValue = function(
@@ -991,7 +1819,7 @@
           $typeVarMapBox[0][t.name].valuesByPath
         );
       }
-    } else if (!test(env, t, value)) {
+    } else if (!$.test(env, t, value)) {
       throw invalidValue(env, typeInfo, index, propPath, value);
     }
   };
@@ -1340,10 +2168,10 @@
 
   //  create :: Options -> Function
   $.create = function(opts) {
-    assertRight(satisfactoryTypes(defaultEnv,
+    assertRight(satisfactoryTypes($.env,
                                   {name: 'create',
                                    constraints: {},
-                                   types: [Options, AnyFunction]},
+                                   types: [Options, $.AnyFunction]},
                                   {},
                                   Options,
                                   0,
@@ -1432,13 +2260,13 @@
         }
 
         var types = [$.String,
-                     StrMap($.Array(TypeClass)),
+                     $.StrMap($.Array(TypeClass)),
                      $.Array(Type),
-                     AnyFunction,
-                     AnyFunction];
+                     $.AnyFunction,
+                     $.AnyFunction];
         var typeInfo = {name: 'def', constraints: {}, types: types};
         forEach.call(arguments, function(arg, idx) {
-          assertRight(satisfactoryTypes(defaultEnv,
+          assertRight(satisfactoryTypes($.env,
                                         typeInfo,
                                         {},
                                         types[idx],
@@ -1465,3 +2293,40 @@
   return $;
 
 }));
+
+//. [FL:Semigroup]:         https://github.com/fantasyland/fantasy-land#semigroup
+//. [`AnyFunction`]:        #AnyFunction
+//. [`Arguments`]:          #Arguments
+//. [`Array`]:              #Array
+//. [`BinaryType`]:         #BinaryType
+//. [`Boolean`]:            #Boolean
+//. [`Date`]:               #Date
+//. [`Error`]:              #Error
+//. [`FiniteNumber`]:       #FiniteNumber
+//. [`Integer`]:            #Integer
+//. [`Null`]:               #Null
+//. [`Number`]:             #Number
+//. [`Object`]:             #Object
+//. [`Object.create`]:      https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/create
+//. [`Pair`]:               #Pair
+//. [`RegExp`]:             #RegExp
+//. [`StrMap`]:             #StrMap
+//. [`String`]:             #String
+//. [`SyntaxError`]:        https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SyntaxError
+//. [`TypeClass`]:          https://github.com/sanctuary-js/sanctuary-type-classes#TypeClass
+//. [`TypeError`]:          https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypeError
+//. [`TypeVariable`]:       #TypeVariable
+//. [`UnaryType`]:          #UnaryType
+//. [`UnaryTypeVariable`]:  #UnaryTypeVariable
+//. [`Undefined`]:          #Undefined
+//. [`ValidNumber`]:        #ValidNumber
+//. [`env`]:                #env
+//. [arguments]:            https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/arguments
+//. [enumerated types]:     https://en.wikipedia.org/wiki/Enumerated_type
+//. [max]:                  https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/MAX_SAFE_INTEGER
+//. [min]:                  https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/MIN_SAFE_INTEGER
+//. [record type]:          #RecordType
+//. [semigroup]:            https://en.wikipedia.org/wiki/Semigroup
+//. [type class]:           #type-classes
+//. [type variables]:       #TypeVariable
+//. [types]:                #types

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "mocha": "3.x.x",
     "remember-bower": "0.1.x",
     "sanctuary-style": "0.3.x",
+    "transcribe": "0.5.x",
     "xyz": "1.1.x"
   },
   "files": [

--- a/scripts/prepublish
+++ b/scripts/prepublish
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -e
 
+rm -f README.md
 make
-git add LICENSE
+git add LICENSE README.md


### PR DESCRIPTION
For quite some time it has bothered me that sanctuary-def does not use [Transcribe][1] as all the other Sanctuary projects do. Now that we have [sanctuary.js.org][2] it's particularly important that all the projects are documented in the same manner: it will allow us to use [`generate`][3] to publish *all* the Sanctuary projects on the website, not just Sanctuary itself.

This pull request copies the documentation to __index.js__. From this point forward we will no longer update __README.md__ directly. In order to get an idea of the changes that will be made to __README.md__ when we release `sanctuary-def@0.7.0`, I've included a proof. I'll revert the changes to __README.md__ before merging this pull request.

:memo:


[1]: https://github.com/plaid/transcribe
[2]: https://sanctuary.js.org/
[3]: https://github.com/sanctuary-js/sanctuary-site/blob/gh-pages/scripts/generate
