### PR TITLE
types: define {Global,NonGlobal}RegExp

### DIFF
--- a/index.js
+++ b/index.js
@@ -477,6 +477,16 @@
     return createType(FUNCTION, '', format, test, $keys, $types);
   };
 
+  //# GlobalRegExp :: Type
+  //.
+  //. Type comprising every [`RegExp`][] value whose `global` flag is `true`.
+  //.
+  //. See also [`NonGlobalRegExp`][].
+  $.GlobalRegExp = NullaryType(
+    'sanctuary-def/GlobalRegExp',
+    function(x) { return $.RegExp._test(x) && x.global; }
+  );
+
   //# Integer :: Type
   //.
   //. Type comprising every integer in the range
@@ -513,6 +523,16 @@
   $.NegativeNumber = NullaryType(
     'sanctuary-def/NegativeNumber',
     function(x) { return $.Number._test(x) && x < 0; }
+  );
+
+  //# NonGlobalRegExp :: Type
+  //.
+  //. Type comprising every [`RegExp`][] value whose `global` flag is `false`.
+  //.
+  //. See also [`GlobalRegExp`][].
+  $.NonGlobalRegExp = NullaryType(
+    'sanctuary-def/NonGlobalRegExp',
+    function(x) { return $.RegExp._test(x) && !x.global; }
   );
 
   //# NonZeroFiniteNumber :: Type
@@ -2303,7 +2323,9 @@
 //. [`Date`]:               #Date
 //. [`Error`]:              #Error
 //. [`FiniteNumber`]:       #FiniteNumber
+//. [`GlobalRegExp`]:       #GlobalRegExp
 //. [`Integer`]:            #Integer
+//. [`NonGlobalRegExp`]:    #NonGlobalRegExp
 //. [`Null`]:               #Null
 //. [`Number`]:             #Number
 //. [`Object`]:             #Object

--- a/test/index.js
+++ b/test/index.js
@@ -1455,6 +1455,42 @@ describe('def', function() {
     eq(isNegativeInteger(new Number(-1)), true);
   });
 
+  it('supports the "GlobalRegExp" type', function() {
+    eq($.GlobalRegExp.name, 'sanctuary-def/GlobalRegExp');
+
+    var isGlobalRegExp = function(x) {
+      return $.test($.env, $.GlobalRegExp, x);
+    };
+    eq(isGlobalRegExp(null), false);
+    eq(isGlobalRegExp({global: true}), false);
+    eq(isGlobalRegExp(/x/), false);
+    eq(isGlobalRegExp(/x/i), false);
+    eq(isGlobalRegExp(/x/m), false);
+    eq(isGlobalRegExp(/x/im), false);
+    eq(isGlobalRegExp(/x/g), true);
+    eq(isGlobalRegExp(/x/gi), true);
+    eq(isGlobalRegExp(/x/gm), true);
+    eq(isGlobalRegExp(/x/gim), true);
+  });
+
+  it('supports the "NonGlobalRegExp" type', function() {
+    eq($.NonGlobalRegExp.name, 'sanctuary-def/NonGlobalRegExp');
+
+    var isNonGlobalRegExp = function(x) {
+      return $.test($.env, $.NonGlobalRegExp, x);
+    };
+    eq(isNonGlobalRegExp(null), false);
+    eq(isNonGlobalRegExp({global: false}), false);
+    eq(isNonGlobalRegExp(/x/g), false);
+    eq(isNonGlobalRegExp(/x/gi), false);
+    eq(isNonGlobalRegExp(/x/gm), false);
+    eq(isNonGlobalRegExp(/x/gim), false);
+    eq(isNonGlobalRegExp(/x/), true);
+    eq(isNonGlobalRegExp(/x/i), true);
+    eq(isNonGlobalRegExp(/x/m), true);
+    eq(isNonGlobalRegExp(/x/im), true);
+  });
+
   it('supports the "RegexFlags" type', function() {
     var isRegexFlags = function(x) {
       return $.test($.env, $.RegexFlags, x);


### PR DESCRIPTION
These types are required in sanctuary-js/sanctuary#283. It's better to define them publicly here than to define them privately in Sanctuary, as they may prove useful in other contexts.
