### PR TITLE
add ‘name’ and ‘url’ parameters to $.EnumType

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -1060,11 +1060,11 @@ describe('def', function() {
 
   it('supports enumerated types', function() {
     eq(typeof $.EnumType, 'function');
-    eq($.EnumType.length, 1);
-    eq($.EnumType.toString(), 'EnumType :: Array Any -> Type');
+    eq($.EnumType.length, 3);
+    eq($.EnumType.toString(), 'EnumType :: String -> String -> Array Any -> Type');
 
     //  TimeUnit :: Type
-    var TimeUnit = $.EnumType(['milliseconds', 'seconds', 'minutes', 'hours']);
+    var TimeUnit = $.EnumType('my-package/TimeUnit', '', ['milliseconds', 'seconds', 'minutes', 'hours']);
 
     //  convertTo :: TimeUnit -> ValidDate -> ValidNumber
     var convertTo =
@@ -1084,18 +1084,18 @@ describe('def', function() {
            TypeError,
            'Invalid value\n' +
            '\n' +
-           'convertTo :: ("milliseconds" | "seconds" | "minutes" | "hours") -> ValidDate -> ValidNumber\n' +
-           '             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n' +
-           '                                     1\n' +
+           'convertTo :: TimeUnit -> ValidDate -> ValidNumber\n' +
+           '             ^^^^^^^^\n' +
+           '                1\n' +
            '\n' +
            '1)  "days" :: String\n' +
            '\n' +
-           'The value at position 1 is not a member of ‘("milliseconds" | "seconds" | "minutes" | "hours")’.\n');
+           'The value at position 1 is not a member of ‘TimeUnit’.\n');
 
     eq(convertTo('seconds', new Date(1000)), 1);
 
     //  SillyType :: Type
-    var SillyType = $.EnumType(['foo', true, 42]);
+    var SillyType = $.EnumType('my-package/SillyType', '', ['foo', true, 42]);
 
     var _env = $.env.concat([SillyType]);
     var _def = $.create({checkTypes: true, env: _env});
@@ -1677,8 +1677,8 @@ describe('def', function() {
   });
 
   it('provides the "RegexFlags" type', function() {
-    eq($.RegexFlags.name, '');
-    eq($.RegexFlags.url, '');
+    eq($.RegexFlags.name, 'sanctuary-def/RegexFlags');
+    eq($.RegexFlags.url, 'https://github.com/sanctuary-js/sanctuary-def/tree/v' + version + '#RegexFlags');
 
     function isRegexFlags(x) {
       return $.test($.env, $.RegexFlags, x);


### PR DESCRIPTION
This commit makes `$.EnumType` a thin wrapper around `$.NullaryType`. The ability to give an enumerated type a descriptive name has been requested in the past. Now that we have the ability to associate a documentation URL with a type there's no longer much value in enumerating all possible values in an error message.

Before:

```javascript
S.regex('^x', 'gm');
// ! TypeError: Invalid value
//
//   regex :: ("" | "g" | "i" | "m" | "gi" | "gm" | "im" | "gim") -> String -> RegExp
//            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
//                                     1
//
//   1)  "^x" :: String
//
//   The value at position 1 is not a member of ‘("" | "g" | "i" | "m" | "gi" | "gm" | "im" | "gim")’.
```

After:

```javascript
S.regex('^x', 'gm');
// ! TypeError: Invalid value
//
//   regex :: RegexFlags -> String -> RegExp
//            ^^^^^^^^^^
//                1
//
//   1)  "^x" :: String
//
//   The value at position 1 is not a member of ‘RegexFlags’.
//
//   See https://github.com/sanctuary-js/sanctuary-def/tree/v0.8.0#RegexFlags for information about the sanctuary-def/RegexFlags type.
```

Is this an improvement, do you think?
