### PR TITLE
modify AnyFunction to include generator functions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-ESLINT = node_modules/.bin/eslint --config node_modules/sanctuary-style/eslint-es3.json --env es3
+ESLINT = node_modules/.bin/eslint --config node_modules/sanctuary-style/eslint-es3.json
 ISTANBUL = node_modules/.bin/istanbul
 NPM = npm
 REMARK = node_modules/.bin/remark --frail --no-stdout
@@ -27,6 +27,7 @@ README.md: index.js
 .PHONY: lint
 lint:
 	$(ESLINT) \
+	  --env es3 \
 	  --global define \
 	  --global module \
 	  --global require \
@@ -34,6 +35,7 @@ lint:
 	  --rule 'max-len: [error, {code: 79, ignorePattern: "^ *//(# |[.] // |[.]   - <code>)", ignoreUrls: true}]' \
 	  -- index.js
 	$(ESLINT) \
+	  --env es6 \
 	  --env node \
 	  --env mocha \
 	  --rule 'dot-notation: [error, {allowKeywords: true}]' \

--- a/index.js
+++ b/index.js
@@ -447,7 +447,7 @@
   //# AnyFunction :: Type
   //.
   //. Type comprising every Function value.
-  var AnyFunction = NullaryTypeWithUrl('Function', typeEq('Function'));
+  var AnyFunction = NullaryTypeWithUrl('Function', typeofEq('function'));
 
   //# Arguments :: Type
   //.

--- a/test/index.js
+++ b/test/index.js
@@ -1369,6 +1369,7 @@ describe('def', function() {
     eq(isAnyFunction(null), false);
     eq(isAnyFunction(Math.abs), true);
     eq(isAnyFunction(Identity), true);
+    eq(isAnyFunction(function*(x) { return x; }), true);
   });
 
   it('provides the "Arguments" type', function() {


### PR DESCRIPTION
Using `typeofEq('function')` for the [AnyFunction](https://github.com/sanctuary-js/sanctuary-def/blob/v0.9.0/index.js#L431-L434) to include generator functions.
__Note:__ The test uses a generator function (`function*(x){... ` ) but that causes the es3 linter to report a parse error on the `*`.. Is there any way to avoid this?