### PR TITLE
types: define NonEmpty type constructor

### DIFF
--- a/index.js
+++ b/index.js
@@ -569,6 +569,23 @@
     function(x) { return Number_._test(x) && x < 0; }
   );
 
+  //# NonEmpty :: Type -> Type
+  //.
+  //. Constructor for non-empty types. `$.NonEmpty($.String)`, for example, is
+  //. the type comprising every [`String`][] value except `''`.
+  //.
+  //. The given type must satisfy the [Monoid][] and [Setoid][] specifications.
+  var NonEmpty = UnaryType(
+    'sanctuary-def/NonEmpty',
+    functionUrl('NonEmpty'),
+    function(x) {
+      return Z.Monoid.test(x) &&
+             Z.Setoid.test(x) &&
+             !Z.equals(x, Z.empty(x.constructor));
+    },
+    function(monoid) { return [monoid]; }
+  );
+
   //# NonGlobalRegExp :: Type
   //.
   //. Type comprising every [`RegExp`][] value whose `global` flag is `false`.
@@ -2406,7 +2423,7 @@
                {},
                [String_,
                 StrMap(Array_(TypeClass)),
-                Array_(Type),
+                NonEmpty(Array_(Type)),
                 AnyFunction,
                 AnyFunction],
                def);
@@ -2450,6 +2467,7 @@
     NegativeFiniteNumber: NegativeFiniteNumber,
     NegativeInteger: NegativeInteger,
     NegativeNumber: NegativeNumber,
+    NonEmpty: NonEmpty,
     NonGlobalRegExp: NonGlobalRegExp,
     NonZeroFiniteNumber: NonZeroFiniteNumber,
     NonZeroInteger: NonZeroInteger,
@@ -2489,6 +2507,8 @@
 }));
 
 //. [FL:Semigroup]:         https://github.com/fantasyland/fantasy-land#semigroup
+//. [Monoid]:               https://github.com/fantasyland/fantasy-land#monoid
+//. [Setoid]:               https://github.com/fantasyland/fantasy-land#setoid
 //. [`Array`]:              #Array
 //. [`BinaryType`]:         #BinaryType
 //. [`Date`]:               #Date
@@ -2501,6 +2521,7 @@
 //. [`Pair`]:               #Pair
 //. [`RegExp`]:             #RegExp
 //. [`RegexFlags`]:         #RegexFlags
+//. [`String`]:             #String
 //. [`SyntaxError`]:        https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SyntaxError
 //. [`TypeClass`]:          https://github.com/sanctuary-js/sanctuary-type-classes#TypeClass
 //. [`TypeError`]:          https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypeError

--- a/test/index.js
+++ b/test/index.js
@@ -253,7 +253,7 @@ describe('def', function() {
            TypeError,
            'Invalid value\n' +
            '\n' +
-           'def :: String -> StrMap (Array TypeClass) -> Array Type -> Function -> Function\n' +
+           'def :: String -> StrMap (Array TypeClass) -> NonEmpty (Array Type) -> Function -> Function\n' +
            '       ^^^^^^\n' +
            '         1\n' +
            '\n' +
@@ -267,7 +267,7 @@ describe('def', function() {
            TypeError,
            'Invalid value\n' +
            '\n' +
-           'def :: String -> StrMap (Array TypeClass) -> Array Type -> Function -> Function\n' +
+           'def :: String -> StrMap (Array TypeClass) -> NonEmpty (Array Type) -> Function -> Function\n' +
            '                 ^^^^^^^^^^^^^^^^^^^^^^^^\n' +
            '                            1\n' +
            '\n' +
@@ -277,27 +277,27 @@ describe('def', function() {
            '\n' +
            'See https://github.com/sanctuary-js/sanctuary-def/tree/v' + version + '#StrMap for information about the sanctuary-def/StrMap type.\n');
 
-    throws(function() { def('', {}, null, null); },
+    throws(function() { def('', {}, [], null); },
            TypeError,
            'Invalid value\n' +
            '\n' +
-           'def :: String -> StrMap (Array TypeClass) -> Array Type -> Function -> Function\n' +
-           '                                             ^^^^^^^^^^\n' +
-           '                                                 1\n' +
+           'def :: String -> StrMap (Array TypeClass) -> NonEmpty (Array Type) -> Function -> Function\n' +
+           '                                             ^^^^^^^^^^^^^^^^^^^^^\n' +
+           '                                                       1\n' +
            '\n' +
-           '1)  null :: Null\n' +
+           '1)  [] :: Array ???\n' +
            '\n' +
-           'The value at position 1 is not a member of ‘Array Type’.\n' +
+           'The value at position 1 is not a member of ‘NonEmpty (Array Type)’.\n' +
            '\n' +
-           'See https://github.com/sanctuary-js/sanctuary-def/tree/v' + version + '#Array for information about the Array type.\n');
+           'See https://github.com/sanctuary-js/sanctuary-def/tree/v' + version + '#NonEmpty for information about the sanctuary-def/NonEmpty type.\n');
 
     throws(function() { def('', {}, [1, 2, 3], null); },
            TypeError,
            'Invalid value\n' +
            '\n' +
-           'def :: String -> StrMap (Array TypeClass) -> Array Type -> Function -> Function\n' +
-           '                                                   ^^^^\n' +
-           '                                                    1\n' +
+           'def :: String -> StrMap (Array TypeClass) -> NonEmpty (Array Type) -> Function -> Function\n' +
+           '                                                             ^^^^\n' +
+           '                                                              1\n' +
            '\n' +
            '1)  1 :: Number\n' +
            '\n' +
@@ -305,13 +305,13 @@ describe('def', function() {
            '\n' +
            'See https://github.com/sanctuary-js/sanctuary-def/tree/v' + version + '#Type for information about the Type type.\n');
 
-    throws(function() { def('', {}, [], null); },
+    throws(function() { def('', {}, [$.Null], null); },
            TypeError,
            'Invalid value\n' +
            '\n' +
-           'def :: String -> StrMap (Array TypeClass) -> Array Type -> Function -> Function\n' +
-           '                                                           ^^^^^^^^\n' +
-           '                                                              1\n' +
+           'def :: String -> StrMap (Array TypeClass) -> NonEmpty (Array Type) -> Function -> Function\n' +
+           '                                                                      ^^^^^^^^\n' +
+           '                                                                         1\n' +
            '\n' +
            '1)  null :: Null\n' +
            '\n' +
@@ -1440,6 +1440,18 @@ describe('def', function() {
   it('provides the "Function" type constructor', function() {
     eq($.Function([a, a]).name, '');
     eq($.Function([a, a]).url, '');
+  });
+
+  it('provides the "NonEmpty" type constructor', function() {
+    eq($.NonEmpty($.String).name, 'sanctuary-def/NonEmpty');
+    eq($.NonEmpty($.String).url, 'https://github.com/sanctuary-js/sanctuary-def/tree/v' + version + '#NonEmpty');
+
+    function isNonEmptyIntegerArray(x) {
+      return $.test($.env, $.NonEmpty($.Array($.Integer)), x);
+    }
+    eq(isNonEmptyIntegerArray([]), false);
+    eq(isNonEmptyIntegerArray([0]), true);
+    eq(isNonEmptyIntegerArray([0.5]), false);
   });
 
   it('provides the "Null" type', function() {


### PR DESCRIPTION
I'll explain how I arrived at this pull request.

1.  I wrote something like this, forgetting to specify the types:

    ```javascript
    const f = def('f', {}, [], _f);
    ```

2.  I ran the code and got an unhelpful error message:

    ```
    RangeError: Invalid array length
    ```

3.  I set out to add a length check and a custom error message for an empty type array.

4.  I remembered that we have an elegant way to avoid ad hoc type checking. :D

5.  I defined `NonEmptyArray` for internal use to improve the error message.

6.  I decided to export `NonEmptyArray` (and `NonEmptyString`, for symmetry).
