### PR TITLE
sanctuary-type-classes@6.0.x

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -21,7 +21,7 @@
     "types"
   ],
   "dependencies": {
-    "sanctuary-type-classes": "5.1.x",
+    "sanctuary-type-classes": "6.0.x",
     "sanctuary-type-identifiers": "1.0.x"
   },
   "ignore": [

--- a/index.js
+++ b/index.js
@@ -1919,6 +1919,7 @@
   //. //    Semigroup :: TypeClass
   //. const Semigroup = Z.TypeClass(
   //.   'my-package/Semigroup',
+  //.   'http://example.com/my-package#Semigroup',
   //.   [],
   //.   x => x != null && typeof x.concat === 'function'
   //. );
@@ -1940,6 +1941,8 @@
   //. //   1)  {} :: Object, StrMap ???
   //. //
   //. //   ‘concat’ requires ‘a’ to satisfy the Semigroup type-class constraint; the value at position 1 does not.
+  //. //
+  //. //   See http://example.com/my-package#Semigroup for information about the my-package/Semigroup type class.
   //.
   //. concat(null, null);
   //. // ! TypeError: Type-class constraint violation
@@ -1951,6 +1954,8 @@
   //. //   1)  null :: Null
   //. //
   //. //   ‘concat’ requires ‘a’ to satisfy the Semigroup type-class constraint; the value at position 1 does not.
+  //. //
+  //. //   See http://example.com/my-package#Semigroup for information about the my-package/Semigroup type class.
   //. ```
   //.
   //. Multiple constraints may be placed on a type variable by including
@@ -2179,6 +2184,13 @@
     };
   }
 
+  //  see :: (String, { name :: String, url :: String }) -> String
+  function see(label, record) {
+    return record.url &&
+           '\nSee ' + record.url +
+           ' for information about the ' + record.name + ' ' + label + '.\n';
+  }
+
   //  typeClassConstraintViolation :: ... -> Error
   function typeClassConstraintViolation(
     env,            // :: Array Type
@@ -2205,7 +2217,8 @@
       showValuesAndTypes(env, [value], 1) + '\n\n' +
       q(typeInfo.name) + ' requires ' + q(expType.name) + ' to satisfy the ' +
       stripNamespace(typeClass.name) + ' type-class constraint; ' +
-      'the value at position 1 does not.\n'
+      'the value at position 1 does not.\n' +
+      see('type class', typeClass)
     ));
   }
 
@@ -2272,8 +2285,7 @@
       showValuesAndTypes(env, [value], 1) + '\n\n' +
       'The value at position 1 is not a member of ' + showTypeQuoted(t) + '.' +
       '\n' +
-      (t.url &&
-       '\nSee ' + t.url + ' for information about the ' + t.name + ' type.\n')
+      see('type', t)
     ));
   }
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test": "make test lint"
   },
   "dependencies": {
-    "sanctuary-type-classes": "5.1.x",
+    "sanctuary-type-classes": "6.0.x",
     "sanctuary-type-identifiers": "1.0.x"
   },
   "devDependencies": {

--- a/test/index.js
+++ b/test/index.js
@@ -4,6 +4,7 @@ var assert = require('assert');
 var vm = require('vm');
 
 var Z = require('sanctuary-type-classes');
+var Z$version = require('sanctuary-type-classes/package.json').version;
 var type = require('sanctuary-type-identifiers');
 
 var $ = require('..');
@@ -2631,7 +2632,9 @@ describe('def', function() {
            '\n' +
            '1)  Left(1) :: Either Number ???, Either Integer ???\n' +
            '\n' +
-           '‘alt’ requires ‘a’ to satisfy the Alternative type-class constraint; the value at position 1 does not.\n');
+           '‘alt’ requires ‘a’ to satisfy the Alternative type-class constraint; the value at position 1 does not.\n' +
+           '\n' +
+           'See https://github.com/sanctuary-js/sanctuary-type-classes/tree/v' + Z$version + '#Alternative for information about the sanctuary-type-classes/Alternative type class.\n');
 
     throws(function() { alt($.__, Right(1)); },
            TypeError,
@@ -2643,7 +2646,9 @@ describe('def', function() {
            '\n' +
            '1)  Right(1) :: Either ??? Number, Either ??? Integer\n' +
            '\n' +
-           '‘alt’ requires ‘a’ to satisfy the Alternative type-class constraint; the value at position 1 does not.\n');
+           '‘alt’ requires ‘a’ to satisfy the Alternative type-class constraint; the value at position 1 does not.\n' +
+           '\n' +
+           'See https://github.com/sanctuary-js/sanctuary-type-classes/tree/v' + Z$version + '#Alternative for information about the sanctuary-type-classes/Alternative type class.\n');
 
     //  concat :: Semigroup a => a -> a -> a
     var concat = def('concat', {a: [Z.Semigroup]}, [a, a, a], Z.concat);
@@ -2661,7 +2666,9 @@ describe('def', function() {
            '\n' +
            '1)  /x/ :: RegExp\n' +
            '\n' +
-           '‘concat’ requires ‘a’ to satisfy the Semigroup type-class constraint; the value at position 1 does not.\n');
+           '‘concat’ requires ‘a’ to satisfy the Semigroup type-class constraint; the value at position 1 does not.\n' +
+           '\n' +
+           'See https://github.com/sanctuary-js/sanctuary-type-classes/tree/v' + Z$version + '#Semigroup for information about the sanctuary-type-classes/Semigroup type class.\n');
 
     throws(function() { concat($.__, /x/); },
            TypeError,
@@ -2673,7 +2680,9 @@ describe('def', function() {
            '\n' +
            '1)  /x/ :: RegExp\n' +
            '\n' +
-           '‘concat’ requires ‘a’ to satisfy the Semigroup type-class constraint; the value at position 1 does not.\n');
+           '‘concat’ requires ‘a’ to satisfy the Semigroup type-class constraint; the value at position 1 does not.\n' +
+           '\n' +
+           'See https://github.com/sanctuary-js/sanctuary-type-classes/tree/v' + Z$version + '#Semigroup for information about the sanctuary-type-classes/Semigroup type class.\n');
 
     throws(function() { concat([], ''); },
            TypeError,
@@ -2727,7 +2736,9 @@ describe('def', function() {
            '\n' +
            '1)  Right(42) :: Either ??? Number, Either ??? Integer\n' +
            '\n' +
-           '‘filter’ requires ‘m’ to satisfy the Alternative type-class constraint; the value at position 1 does not.\n');
+           '‘filter’ requires ‘m’ to satisfy the Alternative type-class constraint; the value at position 1 does not.\n' +
+           '\n' +
+           'See https://github.com/sanctuary-js/sanctuary-type-classes/tree/v' + Z$version + '#Alternative for information about the sanctuary-type-classes/Alternative type class.\n');
 
     //  concatMaybes :: Semigroup a => Maybe a -> Maybe a -> Maybe a
     var concatMaybes =
@@ -2746,7 +2757,9 @@ describe('def', function() {
            '\n' +
            '1)  /xxx/ :: RegExp\n' +
            '\n' +
-           '‘concatMaybes’ requires ‘a’ to satisfy the Semigroup type-class constraint; the value at position 1 does not.\n');
+           '‘concatMaybes’ requires ‘a’ to satisfy the Semigroup type-class constraint; the value at position 1 does not.\n' +
+           '\n' +
+           'See https://github.com/sanctuary-js/sanctuary-type-classes/tree/v' + Z$version + '#Semigroup for information about the sanctuary-type-classes/Semigroup type class.\n');
 
     throws(function() { concatMaybes(Just('abc'), Just(/xxx/)); },
            TypeError,
@@ -2758,7 +2771,9 @@ describe('def', function() {
            '\n' +
            '1)  /xxx/ :: RegExp\n' +
            '\n' +
-           '‘concatMaybes’ requires ‘a’ to satisfy the Semigroup type-class constraint; the value at position 1 does not.\n');
+           '‘concatMaybes’ requires ‘a’ to satisfy the Semigroup type-class constraint; the value at position 1 does not.\n' +
+           '\n' +
+           'See https://github.com/sanctuary-js/sanctuary-type-classes/tree/v' + Z$version + '#Semigroup for information about the sanctuary-type-classes/Semigroup type class.\n');
 
     throws(function() { concatMaybes(Just('abc'), Just('def')); },
            TypeError,
@@ -2770,7 +2785,9 @@ describe('def', function() {
            '\n' +
            '1)  /xxx/ :: RegExp\n' +
            '\n' +
-           '‘concatMaybes’ requires ‘a’ to satisfy the Semigroup type-class constraint; the value at position 1 does not.\n');
+           '‘concatMaybes’ requires ‘a’ to satisfy the Semigroup type-class constraint; the value at position 1 does not.\n' +
+           '\n' +
+           'See https://github.com/sanctuary-js/sanctuary-type-classes/tree/v' + Z$version + '#Semigroup for information about the sanctuary-type-classes/Semigroup type class.\n');
 
     //  sillyConst :: (Alternative a, Semigroup b) => a -> b -> a
     var sillyConst =
@@ -2791,7 +2808,9 @@ describe('def', function() {
            '\n' +
            '1)  true :: Boolean\n' +
            '\n' +
-           '‘sillyConst’ requires ‘a’ to satisfy the Alternative type-class constraint; the value at position 1 does not.\n');
+           '‘sillyConst’ requires ‘a’ to satisfy the Alternative type-class constraint; the value at position 1 does not.\n' +
+           '\n' +
+           'See https://github.com/sanctuary-js/sanctuary-type-classes/tree/v' + Z$version + '#Alternative for information about the sanctuary-type-classes/Alternative type class.\n');
   });
 
   it('supports unary type variables', function() {
@@ -2853,7 +2872,9 @@ describe('def', function() {
            '\n' +
            '1)  42 :: Number\n' +
            '\n' +
-           '‘sum’ requires ‘f’ to satisfy the Foldable type-class constraint; the value at position 1 does not.\n');
+           '‘sum’ requires ‘f’ to satisfy the Foldable type-class constraint; the value at position 1 does not.\n' +
+           '\n' +
+           'See https://github.com/sanctuary-js/sanctuary-type-classes/tree/v' + Z$version + '#Foldable for information about the sanctuary-type-classes/Foldable type class.\n');
 
     throws(function() { sum(Just(Infinity)); },
            TypeError,
@@ -2900,7 +2921,9 @@ describe('def', function() {
            '\n' +
            '1)  function sin() { [native code] } :: Function\n' +
            '\n' +
-           '‘sort’ requires ‘a’ to satisfy the Ord type-class constraint; the value at position 1 does not.\n');
+           '‘sort’ requires ‘a’ to satisfy the Ord type-class constraint; the value at position 1 does not.\n' +
+           '\n' +
+           'See https://github.com/sanctuary-js/sanctuary-type-classes/tree/v' + Z$version + '#Ord for information about the sanctuary-type-classes/Ord type class.\n');
   });
 
   it('supports binary type variables', function() {


### PR DESCRIPTION
<https://github.com/sanctuary-js/sanctuary-type-classes/compare/v5.1.0...v6.0.0>

Thanks to sanctuary-js/sanctuary-type-classes#57 we can now link to a type class's documentation from the error message for a type-class constraint violation.
