### PR TITLE
sanctuary-type-identifiers@2.0.x

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -22,7 +22,7 @@
   ],
   "dependencies": {
     "sanctuary-type-classes": "6.0.x",
-    "sanctuary-type-identifiers": "1.0.x"
+    "sanctuary-type-identifiers": "2.0.x"
   },
   "ignore": [
     "/.git/",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "sanctuary-type-classes": "6.0.x",
-    "sanctuary-type-identifiers": "1.0.x"
+    "sanctuary-type-identifiers": "2.0.x"
   },
   "devDependencies": {
     "eslint": "3.19.x",


### PR DESCRIPTION
<https://github.com/sanctuary-js/sanctuary-type-identifiers/compare/v1.0.0...v2.0.1>

The changes above aren't yet of significance to this project, but keeping dependencies up to date benefits Sanctuary users by preventing multiple versions of sanctuary-type-identifiers from being downloaded.
