### PR TITLE
Allow see() to handle records without URLs

### DIFF
--- a/index.js
+++ b/index.js
@@ -2191,9 +2191,10 @@
     };
   }
 
-  //  see :: (String, { name :: String, url :: String }) -> String
+  //  see :: (String, { name :: String, url :: String? }) -> String
   function see(label, record) {
-    return record.url &&
+    return record.url == null || record.url === '' ?
+           '' :
            '\nSee ' + record.url +
            ' for information about the ' + record.name + ' ' + label + '.\n';
   }


### PR DESCRIPTION
See https://github.com/sanctuary-js/sanctuary-def/pull/153#discussion_r119550590

Commit body:

> This ensures that records like the ones created by older
versions of sanctuary-type-classes are not being treated
like garbage. As a result we don't see "undefined" in
error messages generated using records with missing
"url" properties.