### PR TITLE
ensure that _determineActualTypes returns an array of unique types

### DIFF
--- a/index.js
+++ b/index.js
@@ -312,6 +312,13 @@
     return s.replace(/[ ]+$/gm, '');
   }
 
+  //  unique :: Showable a => Array a -> Array a
+  function unique(xs) {
+    var strMap = {};
+    xs.forEach(function(x) { strMap[Z.toString(x)] = x; });
+    return Object.keys(strMap).map(function(k) { return strMap[k]; });
+  }
+
   //  unless :: (Boolean, (a -> a), a) -> a
   function unless(bool, f, x) {
     return bool ? x : f(x);
@@ -939,7 +946,7 @@
 
     return isEmpty(values) ?
       [Unknown] :
-      or(Z.reduce(refine, env, values), loose ? [Inconsistent] : []);
+      or(unique(Z.reduce(refine, env, values)), loose ? [Inconsistent] : []);
   }
 
   //  rejectInconsistent :: Array Type -> Array Type

--- a/test/index.js
+++ b/test/index.js
@@ -2016,6 +2016,32 @@ describe('def', function() {
     });
   });
 
+  it('lists the types of each value without duplicates', function() {
+    var env = [$.Array($.Unknown), $.Number, $.Integer];
+    var def = $.create({checkTypes: true, env: env});
+
+    //  add :: Number -> Number -> Number
+    var add =
+    def('add',
+        {},
+        [$.Number, $.Number, $.Number],
+        function(x, y) { return x + y; });
+
+    throws(function() { add([[1], [2]]); },
+           TypeError,
+           'Invalid value\n' +
+           '\n' +
+           'add :: Number -> Number -> Number\n' +
+           '       ^^^^^^\n' +
+           '         1\n' +
+           '\n' +
+           '1)  [[1], [2]] :: Array (Array Number), Array (Array Integer)\n' +
+           '\n' +
+           'The value at position 1 is not a member of ‘Number’.\n' +
+           '\n' +
+           'See https://github.com/sanctuary-js/sanctuary-def/tree/v' + version + '#Number for information about the Number type.\n');
+  });
+
   it('supports polymorphism via type variables', function() {
     var env = $.env.concat([Either($.Unknown, $.Unknown), Maybe($.Unknown), $Pair($.Unknown, $.Unknown)]);
     var def = $.create({checkTypes: true, env: env});


### PR DESCRIPTION
Fixes #158

Commit message:

> Any environment consisting of at least one nullary type and at least one non-nullary type describes an infinite number of concrete types. `[$.Array($.Unknown), $.Number]`, for example, describes:
>
>   - `Number`
>   - `Array Number`
>   - `Array (Array Number)`
>   - `Array (Array (Array Number))`
>   - …
>
> It's thus impossible to expand the "unknowns" in the environment to produce a finite set of concrete types (which could then be filtered). Instead, the environment is at once filtered and expanded (whenever an "unknown" is encountered). This may produce duplicate concrete types.
>
> This commit updates `_determineActualTypes` to discard duplicate types.
