### PR TITLE
Type refinements

### DIFF
--- a/index.js
+++ b/index.js
@@ -2602,8 +2602,12 @@
                def);
   }
 
-  var Options = RecordType(Object_, {checkTypes: Boolean_, env: Array_(Type)});
-  var create = def('create', {}, [Options, AnyFunction], _create);
+  var create =
+  def('create',
+      {},
+      [RecordType(Object_, {checkTypes: Boolean_, env: Array_(Type)}),
+       AnyFunction],
+      _create);
 
   //  fromUncheckedUnaryType :: (Type -> Type) -> (Type -> Type)
   function fromUncheckedUnaryType(typeConstructor) {

--- a/index.js
+++ b/index.js
@@ -1788,10 +1788,12 @@
   //. ```
   //.
   //. The `p2` value is a member of `Point3D` as well as `Point`, making it a
-  //. valid argument to `dist`. By default record types allow additional
-  //. properties (which is what allowed `p2` to be a member of `Point`). If one
-  //. wishes for a record type to allow for no additional properties, it can be
-  //. refined using the [`Strict`][] constructor:
+  //. valid argument to `dist`. By default, record types permit the presence
+  //. of additional fields. As a result, p2 is a member of Point as well as
+  //. Point3D.
+  //.
+  //. One could use the [`Strict`][] constructor to define record types which
+  //. do not permit additional fields:
   //.
   //. ```javascript
   //. //    StrictPoint3D :: Type

--- a/index.js
+++ b/index.js
@@ -834,7 +834,9 @@
   //. comprising every object with exactly one field, `name`, of type `String`.
   function Strict(t) {
     function test(x) {
-      return Object.keys(x).length === t.keys.length;
+      var len = 0, o = Object(x);
+      for (var k in o) len += 1; // eslint-disable-line no-unused-vars
+      return t.keys.length === len;
     }
 
     return NullaryType('sanctuary-def/Strict',

--- a/index.js
+++ b/index.js
@@ -1745,37 +1745,38 @@
   //.
   //. ##### Extending record types
   //.
-  //. By using the `parent` argument of the RecordType constructor, one can
+  //. By using the `parent` argument of the `RecordType` constructor, one can
   //. define record types which must contain all the same properties of
-  //. another. For example, one could define `Poinst3D` as a refinement of
+  //. another. For example, one could define `Point3D` as a refinement of
   //. `Point` from the previous example:
   //.
-  //. ```js
+  //. ```javascript
   //. //    Point3D :: Type
   //. const Point3D = $.RecordType(Point, {z: $.FiniteNumber});
   //.
-  //. //    a :: Point
-  //. const a = {x: 0, y: 0};
+  //. //    p1 :: Point
+  //. const p1 = {x: 0, y: 0};
   //.
-  //. //    b :: Point, Point3D
-  //. const b = {x: 3, y: 4, z: 5};
+  //. //    p2 :: Point, Point3D
+  //. const p2 = {x: 3, y: 4, z: 5};
   //.
-  //. Point.validate(a)   // => Right(a)
-  //. Point3D.validate(a) // => Left({propPath: ['z'], value: undefined})
+  //. Point.validate(p1);    // => Right({x: 0, y: 0})
+  //. Point3D.validate(p1);  // => Left({propPath: ['z'], value: undefined})
   //.
-  //. Point.validate(b)   // => Right(b)
-  //. Point3D.validate(b) // => Right(b)
+  //. Point.validate(p2);    // => Right({x: 3, y: 4, z: 5})
+  //. Point3D.validate(p2);  // => Right({x: 3, y: 4, z: 5})
   //.
-  //. dist(a, b);
+  //. dist(p1, p2);
   //. // => 5
   //. ```
   //.
-  //. The `b` value is a member of `Point3D` as well as `Point`, allowing one
-  //. to call `dist` on it. By default record types allow additional
-  //. properties, permitting record "extension". If one wishes for a record
-  //. type to allow for no additional properties, it can be refined as such:
+  //. The `p2` value is a member of `Point3D` as well as `Point`, making it a
+  //. valid argument to `dist`. By default record types allow additional
+  //. properties (which is what allowed `p2` to be a member of `Point`). If one
+  //. wishes for a record type to allow for no additional properties, it can be
+  //. refined as such:
   //.
-  //. ```js
+  //. ```javascript
   //. //    strict :: Type -> Type
   //. const strict = t => $.NullaryType(
   //.   'Strict' + t.name,
@@ -1785,13 +1786,16 @@
   //. );
   //.
   //. //    StrictPoint3D :: Type
-  //. const StrictPoint3D = strict(Point3D)
+  //. const StrictPoint3D = strict(Point3D);
   //.
-  //. //    a :: Point, Point3D
-  //. const a = {x: 1, y: 2, z: 3, color: 'red'}
+  //. //    p :: Point, Point3D
+  //. const p = {x: 1, y: 2, z: 3, color: 'red'};
   //.
-  //. Point3D.validate(a)       // => Right(a)
-  //. StrictPoint3D.validate(a) // => Left({propPath: [], value: a})
+  //. Point3D.validate(p);
+  //. // => Right({x: 1, y: 2, z: 3, color: 'red'})
+  //.
+  //. StrictPoint3D.validate(p);
+  //. // => Left({propPath: [], value: {x: 1, y: 2, z: 3, color: 'red'}})
   //. ```
   function RecordType(parent, fields) {
     var keys = Object.keys(fields).sort();

--- a/index.js
+++ b/index.js
@@ -2598,7 +2598,7 @@
                def);
   }
 
-  var Options = RecordType(Object_, {checkTypes: Boolean_, env: Array_(Any)});
+  var Options = RecordType(Object_, {checkTypes: Boolean_, env: Array_(Type)});
   var create = def('create', {}, [Options, AnyFunction], _create);
 
   //  fromUncheckedUnaryType :: (Type -> Type) -> (Type -> Type)

--- a/index.js
+++ b/index.js
@@ -829,10 +829,9 @@
 
   //# Strict :: Type -> Type
   //.
-  //. Constructor for strict record types. For example:
-  //. `$.Strict($.Record($.Any, {name: $.String}))`, is the type comprising
-  //. every object with a `name :: String` property, without any other
-  //. properties.
+  //. Constructor for strict record types.
+  //. `$.Strict($.Record($.Any, {name: $.String}))`, for example, is the type
+  //. comprising every object with exactly one field, `name`, of type `String`.
   function Strict(t) {
     function test(x) {
       return Object.keys(x).length === t.keys.length;
@@ -1788,9 +1787,9 @@
   //. ```
   //.
   //. The `p2` value is a member of `Point3D` as well as `Point`, making it a
-  //. valid argument to `dist`. By default, record types permit the presence
-  //. of additional fields. As a result, p2 is a member of Point as well as
-  //. Point3D.
+  //. valid argument to `dist`. By default, record types permit the presence of
+  //. additional fields. As a result, `p2` is a member of `Point` as well as
+  //. `Point3D`.
   //.
   //. One could use the [`Strict`][] constructor to define record types which
   //. do not permit additional fields:

--- a/index.js
+++ b/index.js
@@ -435,16 +435,24 @@
     return EnumType(name, functionUrl(name), members);
   }
 
-  //  UnaryTypeWithUrl ::
-  //    (String, Any -> Boolean, t a -> Array a) -> (Type -> Type)
-  function UnaryTypeWithUrl(name, parent, test, _1) {
+  //  UnaryTypeWithUrl :: ... -> (Type -> Type)
+  function UnaryTypeWithUrl(
+    name,           // :: String
+    parent,         // :: Type
+    test,           // :: Any -> Boolean
+    _1              // :: t a -> Array a
+  ) {
     return UnaryType(name, functionUrl(name), parent, test, _1);
   }
 
-  //  BinaryTypeWithUrl ::
-  //    (String, Any -> Boolean, t a b -> Array a, t a b -> Array b) ->
-  //      ((Type, Type) -> Type)
-  function BinaryTypeWithUrl(name, parent, test, _1, _2) {
+  //  BinaryTypeWithUrl :: ... -> ((Type, Type) -> Type)
+  function BinaryTypeWithUrl(
+    name,           // :: String
+    parent,         // :: Type
+    test,           // :: Any -> Boolean
+    _1,             // :: t a b -> Array a
+    _2              // :: t a b -> Array b
+  ) {
     return BinaryType(name, functionUrl(name), parent, test, _1, _2);
   }
 
@@ -1303,9 +1311,9 @@
   //. The environment is only significant if the type contains
   //. [type variables][].
   //.
-  //. Using types as predicates is powerful. One could, for example,
-  //. define a [record type][] for each endpoint of a REST API and
-  //. validate the bodies of incoming POST requests against these types.
+  //. Using types as predicates is powerful. One could, for example, define a
+  //. [record type][] for each endpoint of a REST API and validate the bodies
+  //. of incoming POST requests against these types.
   function test(env, t, x) {
     var typeInfo = {name: 'name', constraints: {}, types: [t]};
     return satisfactoryTypes(env, typeInfo, {}, t, 0, [], [x]).isRight;
@@ -1325,7 +1333,7 @@
   //.
   //.   - the documentation URL of `t` (exposed as `t.url`); and
   //.
-  //.   - the parent of `t` (exposed as `t.parent`);
+  //.   - the parent type of `t` (exposed as `t.parent`);
   //.
   //.   - a predicate which accepts any JavaScript value and returns `true` if
   //.     (and only if) the value is a member of `t`.
@@ -1393,7 +1401,7 @@
       [String_, String_, Type, Function_([Any, Boolean_]), Type],
       NullaryType);
 
-  //# UnaryType :: String -> String -> Type -> (Any -> Boolean) -> ((t a -> Array a) -> (Type -> Type))
+  //# UnaryType :: String -> String -> Type -> (Any -> Boolean) -> (t a -> Array a) -> (Type -> Type)
   //.
   //. Type constructor for types with one type variable (such as [`Array`][]).
   //.
@@ -1403,7 +1411,7 @@
   //.
   //.   - the documentation URL of `t` (exposed as `t.url`);
   //.
-  //.   - the parent of `t` (exposed as `t.parent`);
+  //.   - the parent type of `t` (exposed as `t.parent`);
   //.
   //.   - a predicate which accepts any JavaScript value and returns `true`
   //.     if (and only if) the value is a member of `t x` for some type `x`;
@@ -1516,7 +1524,7 @@
   //.
   //.   - the documentation URL of `t` (exposed as `t.url`);
   //.
-  //.   - the parent of `t` (exposed as `t.parent`);
+  //.   - the parent type of `t` (exposed as `t.parent`);
   //.
   //.   - a predicate which accepts any JavaScript value and returns `true`
   //.     if (and only if) the value is a member of `t x y` for some types
@@ -1608,8 +1616,6 @@
                inner('$1')(String($1)) + outer(' ') +
                inner('$2')(String($2)) + outer(')');
       }
-      var types = {$1: {extractor: _1, type: $1},
-                   $2: {extractor: _2, type: $2}};
       return new _Type(BINARY,
                        name,
                        url,
@@ -1617,7 +1623,8 @@
                        parent,
                        test,
                        ['$1', '$2'],
-                       types);
+                       {$1: {extractor: _1, type: $1},
+                        $2: {extractor: _2, type: $2}});
     };
   }
 
@@ -1872,7 +1879,6 @@
       function format(outer, inner) {
         return outer('(' + name + ' ') + inner('$1')(String($1)) + outer(')');
       }
-      var types = {$1: {extractor: K([]), type: $1}};
       return new _Type(VARIABLE,
                        name,
                        '',
@@ -1880,7 +1886,7 @@
                        Any,
                        K(true),
                        ['$1'],
-                       types);
+                       {$1: {extractor: K([]), type: $1}});
     };
   }
 

--- a/index.js
+++ b/index.js
@@ -1720,9 +1720,6 @@
   //. dist({x: 0, y: 0}, {x: 3, y: 4});
   //. // => 5
   //.
-  //. dist({x: 0, y: 0}, {x: 3, y: 4, color: 'red'});
-  //. // => 5
-  //.
   //. dist({x: 0, y: 0}, {x: NaN, y: NaN});
   //. // ! TypeError: Invalid value
   //. //
@@ -1744,6 +1741,57 @@
   //. //   1)  0 :: Number
   //. //
   //. //   The value at position 1 is not a member of ‘{ x :: FiniteNumber, y :: FiniteNumber }’.
+  //. ```
+  //.
+  //. ##### Extending record types
+  //.
+  //. By using the `parent` argument of the RecordType constructor, we can
+  //. define record types which must contain all the same properties of
+  //. another. For example, we could define `Poinst3D` as a refinement of our
+  //. `Point` from the previous example:
+  //.
+  //. ```js
+  //. //    Point3D :: Type
+  //. const Point3D = $.RecordType(Point, {z: $.FiniteNumber});
+  //.
+  //. //    a :: Point
+  //. const a = {x: 0, y: 0};
+  //.
+  //. //    b :: Point, Point3D
+  //. const b = {x: 3, y: 4, z: 5};
+  //.
+  //. Point.validate(a)   // => Right(a)
+  //. Point3D.validate(a) // => Left({propPath: ['z'], value: undefined})
+  //.
+  //. Point.validate(b)   // => Right(b)
+  //. Point3D.validate(b) // => Right(b)
+  //.
+  //. dist(a, b);
+  //. // => 5
+  //. ```
+  //.
+  //. We can see that `b` is a member of `Point3D` as well as `Point`, allowing
+  //. us to call `dist` on it. By default record types allow additional
+  //. properties, allowing for this "extension". If you wish for a record type
+  //. to allow no additional properties, we can refine it as such:
+  //.
+  //. ```js
+  //. //    strict :: Type -> Type
+  //. const strict = t => $.NullaryType(
+  //.   'Strict' + t.name,
+  //.   '',
+  //.   t,
+  //.   x => Object.keys(x).length === t.keys.length
+  //. );
+  //.
+  //. //    StrictPoint3D :: Type
+  //. const StrictPoint3D = strict(Point3D)
+  //.
+  //. //    a :: Point, Point3D
+  //. const a = {x: 1, y: 2, z: 3, color: 'red'}
+  //.
+  //. Point3D.validate(a)       // => Right(a)
+  //. StrictPoint3D.validate(a) // => Left({propPath: [], value: a})
   //. ```
   function RecordType(parent, fields) {
     var keys = Object.keys(fields).sort();

--- a/index.js
+++ b/index.js
@@ -1747,8 +1747,7 @@
     }
 
     function test(x) {
-      return x != null &&
-             keys.every(function(k) { return hasOwnProperty.call(x, k); });
+      return keys.every(function(k) { return hasOwnProperty.call(x, k); });
     }
 
     var $types = {};

--- a/index.js
+++ b/index.js
@@ -797,17 +797,16 @@
   //. the type comprising every [`String`][] value except `''`.
   //.
   //. The given type must satisfy the [Monoid][] and [Setoid][] specifications.
-  var NonEmpty = UnaryType(
-    'sanctuary-def/NonEmpty',
-    functionUrl('NonEmpty'),
-    Any,
-    function(x) {
+  function NonEmpty(parent) {
+    function test(x) {
       return Z.Monoid.test(x) &&
              Z.Setoid.test(x) &&
              !Z.equals(x, Z.empty(x.constructor));
-    },
-    function(monoid) { return [monoid]; }
-  );
+    }
+    function extract(monoid) { return [monoid]; }
+    var t = UnaryTypeWithUrl('sanctuary-def/NonEmpty', parent, test, extract);
+    return t(parent);
+  }
 
   //# Nullable :: Type -> Type
   //.
@@ -839,13 +838,11 @@
   //. Constructor for strict record types.
   //. `$.Strict($.Record($.Any, {name: $.String}))`, for example, is the type
   //. comprising every object with exactly one field, `name`, of type `String`.
-  function Strict(t) {
-    return NullaryType('sanctuary-def/Strict',
-                       functionUrl('Strict'),
-                       t,
-                       function test(x) {
-                         return t.keys.length === keys(x).length;
-                       });
+  function Strict(parent) {
+    function test(x) { return parent.keys.length === keys(x).length; }
+    function extract(record) { return [record]; }
+    var t = UnaryTypeWithUrl('sanctuary-def/Strict', parent, test, extract);
+    return t(parent);
   }
 
   //# StrMap :: Type -> Type

--- a/index.js
+++ b/index.js
@@ -1745,9 +1745,9 @@
   //.
   //. ##### Extending record types
   //.
-  //. By using the `parent` argument of the RecordType constructor, we can
+  //. By using the `parent` argument of the RecordType constructor, one can
   //. define record types which must contain all the same properties of
-  //. another. For example, we could define `Poinst3D` as a refinement of our
+  //. another. For example, one could define `Poinst3D` as a refinement of
   //. `Point` from the previous example:
   //.
   //. ```js
@@ -1770,10 +1770,10 @@
   //. // => 5
   //. ```
   //.
-  //. We can see that `b` is a member of `Point3D` as well as `Point`, allowing
-  //. us to call `dist` on it. By default record types allow additional
-  //. properties, allowing for this "extension". If you wish for a record type
-  //. to allow no additional properties, we can refine it as such:
+  //. The `b` value is a member of `Point3D` as well as `Point`, allowing one
+  //. to call `dist` on it. By default record types allow additional
+  //. properties, permitting record "extension". If one wishes for a record
+  //. type to allow for no additional properties, it can be refined as such:
   //.
   //. ```js
   //. //    strict :: Type -> Type

--- a/index.js
+++ b/index.js
@@ -1554,7 +1554,7 @@
   //. const $Pair = $.BinaryType(
   //.   pairTypeIdent,
   //.   'http://example.com/my-package#Pair',
-  //.   Any,
+  //.   $.Any,
   //.   x => type(x) === pairTypeIdent,
   //.   pair => [pair[0]],
   //.   pair => [pair[1]]
@@ -1708,7 +1708,7 @@
   //. //    Point :: Type
   //. const Point = $.RecordType($.Any, {
   //.   x: $.FiniteNumber,
-  //.   y: $.FiniteNumber
+  //.   y: $.FiniteNumber,
   //. });
   //.
   //. //    dist :: Point -> Point -> FiniteNumber

--- a/index.js
+++ b/index.js
@@ -827,6 +827,23 @@
     function(pair) { return [pair[1]]; }
   );
 
+  //# Strict :: Type -> Type
+  //.
+  //. Constructor for strict record types. For example:
+  //. `$.Strict($.Record($.Any, {name: $.String}))`, is the type comprising
+  //. every object with a `name :: String` property, without any other
+  //. properties.
+  function Strict(t) {
+    function test(x) {
+      return Object.keys(x).length === t.keys.length;
+    }
+
+    return NullaryType('sanctuary-def/Strict',
+                       functionUrl('Strict'),
+                       t,
+                       test);
+  }
+
   //# StrMap :: Type -> Type
   //.
   //. Constructor for homogeneous Object types.
@@ -1774,27 +1791,22 @@
   //. valid argument to `dist`. By default record types allow additional
   //. properties (which is what allowed `p2` to be a member of `Point`). If one
   //. wishes for a record type to allow for no additional properties, it can be
-  //. refined as such:
+  //. refined using the [`Strict`][] constructor:
   //.
   //. ```javascript
-  //. //    strict :: Type -> Type
-  //. const strict = t => $.NullaryType(
-  //.   'Strict' + t.name,
-  //.   '',
-  //.   t,
-  //.   x => Object.keys(x).length === t.keys.length
-  //. );
-  //.
   //. //    StrictPoint3D :: Type
-  //. const StrictPoint3D = strict(Point3D);
+  //. const StrictPoint3D = Strict(Point3D);
   //.
-  //. //    p :: Point, Point3D
-  //. const p = {x: 1, y: 2, z: 3, color: 'red'};
+  //. //    p3 :: Point, Point3D
+  //. const p3 = {x: 1, y: 2, z: 3, color: 'red'};
   //.
-  //. Point3D.validate(p);
+  //. Point3D.validate(p3);
   //. // => Right({x: 1, y: 2, z: 3, color: 'red'})
   //.
-  //. StrictPoint3D.validate(p);
+  //. StrictPoint3D.validate(p2);
+  //. // => Right({x: 3, y: 4, z: 5})
+  //.
+  //. StrictPoint3D.validate(p3);
   //. // => Left({propPath: [], value: {x: 1, y: 2, z: 3, color: 'red'}})
   //. ```
   function RecordType(parent, fields) {
@@ -2657,6 +2669,7 @@
     RegExp: RegExp_,
     RegexFlags: RegexFlags,
     StrMap: fromUncheckedUnaryType(StrMap),
+    Strict: Strict,
     String: String_,
     Symbol: Symbol_,
     Type: Type,
@@ -2695,6 +2708,7 @@
 //. [`Pair`]:               #Pair
 //. [`RegExp`]:             #RegExp
 //. [`RegexFlags`]:         #RegexFlags
+//. [`Strict`]:             #Strict
 //. [`String`]:             #String
 //. [`SyntaxError`]:        https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SyntaxError
 //. [`TypeClass`]:          https://github.com/sanctuary-js/sanctuary-type-classes#TypeClass

--- a/test/index.js
+++ b/test/index.js
@@ -69,6 +69,7 @@ var MIN_SAFE_INTEGER = -MAX_SAFE_INTEGER;
 var Integer = $.NullaryType(
   'my-package/Integer',
   'http://example.com/my-package#Integer',
+  $.Any,
   function(x) {
     return $.Number._test(x) &&
            Math.floor(x) === Number(x) &&
@@ -3025,6 +3026,7 @@ describe('def', function() {
     var Void = $.NullaryType(
       'my-package/Void',
       'http://example.com/my-package#Void',
+      $.Any,
       function(x) { count += 1; return false; }
     );
 
@@ -3097,10 +3099,10 @@ describe('test', function() {
 
 describe('NullaryType', function() {
 
-  it('is a ternary function', function() {
+  it('is a quaternary function', function() {
     eq(typeof $.NullaryType, 'function');
-    eq($.NullaryType.length, 3);
-    eq($.NullaryType.toString(), 'NullaryType :: String -> String -> (Any -> Boolean) -> Type');
+    eq($.NullaryType.length, 4);
+    eq($.NullaryType.toString(), 'NullaryType :: String -> String -> Type -> (Any -> Boolean) -> Type');
   });
 
 });

--- a/test/index.js
+++ b/test/index.js
@@ -1204,14 +1204,14 @@ describe('def', function() {
 
   it('supports record types', function() {
     eq(typeof $.RecordType, 'function');
-    eq($.RecordType.length, 1);
-    eq($.RecordType.toString(), 'RecordType :: StrMap Type -> Type');
+    eq($.RecordType.length, 2);
+    eq($.RecordType.toString(), 'RecordType :: Type -> StrMap Type -> Type');
 
     //  Point :: Type
-    var Point = $.RecordType({x: $.Number, y: $.Number});
+    var Point = $.RecordType($.Any, {x: $.Number, y: $.Number});
 
     //  Line :: Type
-    var Line = $.RecordType({start: Point, end: Point});
+    var Line = $.RecordType($.Any, {start: Point, end: Point});
 
     //  dist :: Point -> Point -> Number
     var dist = def('dist', {}, [Point, Point, $.Number], function(p, q) {
@@ -1312,13 +1312,13 @@ describe('def', function() {
 
     eq(id([{x: 0, y: 0}, {x: 1, y: 1}]), [{x: 0, y: 0}, {x: 1, y: 1}]);
 
-    throws(function() { $.RecordType({x: /XXX/, y: /XXX/, z: $.Any}); },
+    throws(function() { $.RecordType($.Any, {x: /XXX/, y: /XXX/, z: $.Any}); },
            TypeError,
            'Invalid value\n' +
            '\n' +
-           'RecordType :: StrMap Type -> Type\n' +
-           '                     ^^^^\n' +
-           '                      1\n' +
+           'RecordType :: Type -> StrMap Type -> Type\n' +
+           '                             ^^^^\n' +
+           '                              1\n' +
            '\n' +
            '1)  /XXX/ :: RegExp\n' +
            '\n' +
@@ -1327,7 +1327,7 @@ describe('def', function() {
            'See https://github.com/sanctuary-js/sanctuary-def/tree/v' + version + '#Type for information about the Type type.\n');
 
     //  Foo :: Type
-    var Foo = $.RecordType({x: a, y: a});
+    var Foo = $.RecordType($.Any, {x: a, y: a});
 
     //  foo :: Foo -> Foo
     var foo = def('foo', {}, [Foo, Foo], identity);

--- a/test/index.js
+++ b/test/index.js
@@ -1230,6 +1230,7 @@ describe('def', function() {
     eq(dist({x: 0, y: 0}, {x: 0, y: 0, z: 0}), 0);
     eq(dist({x: 1, y: 1}, {x: 4, y: 5}), 5);
     eq(dist({x: 1, y: 1}, {x: 4, y: 5, z: 6}), 5);
+    eq(dist(Object.assign(Object.create({x: 1}), {y: 1}), {x: 4, y: 5}), 5);
 
     eq(length({start: {x: 1, y: 1}, end: {x: 4, y: 5}}), 5);
     eq(length({start: {x: 1, y: 1}, end: {x: 4, y: 5, z: 6}}), 5);
@@ -1365,11 +1366,16 @@ describe('def', function() {
     //  StrictPoint :: Type
     var StrictPoint = $.Strict(Point);
 
-    //  p :: Point
-    var p = {x: 1, y: 2, z: 3};
+    //  p1 :: Point
+    var p1 = {x: 1, y: 2, z: 3};
 
-    eq($.test([], Point, p), true);
-    eq($.test([], StrictPoint, p), false);
+    //  p2 :: Point, StrictPoint
+    var p2 = Object.assign(Object.create({x: 1}), {y: 2});
+
+    eq($.test([], Point, p1), true);
+    eq($.test([], StrictPoint, p1), false);
+    eq($.test([], Point, p2), true);
+    eq($.test([], StrictPoint, p2), true);
 
   });
 

--- a/test/index.js
+++ b/test/index.js
@@ -3139,7 +3139,7 @@ describe('UnaryType', function() {
 
 describe('BinaryType', function() {
 
-  it('is a sexternary function', function() {
+  it('is a senary function', function() {
     eq(typeof $.BinaryType, 'function');
     eq($.BinaryType.length, 6);
     eq($.BinaryType.toString(), 'BinaryType :: String -> String -> Type -> (Any -> Boolean) -> (t a b -> Array a) -> (t a b -> Array b) -> Function');

--- a/test/index.js
+++ b/test/index.js
@@ -182,6 +182,7 @@ function Right(x) { return new _Either('Right', x); }
 var Either = $.BinaryType(
   'my-package/Either',
   'http://example.com/my-package#Either',
+  $.Any,
   function(x) { return type(x) === 'my-package/Either'; },
   function(either) { return either.isLeft ? [either.value] : []; },
   function(either) { return either.isRight ? [either.value] : []; }
@@ -220,6 +221,7 @@ Pair.prototype.toString = function() {
 var $Pair = $.BinaryType(
   'my-package/Pair',
   'http://example.com/my-package#Pair',
+  $.Any,
   function(x) { return type(x) === 'my-package/Pair'; },
   function(pair) { return [pair[0]]; },
   function(pair) { return [pair[1]]; }
@@ -2477,7 +2479,8 @@ describe('def', function() {
     var Pair = $.BinaryType(
       'my-package/Pair',
       'http://example.com/my-package#Pair',
-      function(x) { return Object.prototype.toString.call(x) === '[object Array]' && x.length === 2; },
+      $.Array($.Any),
+      function(x) { return x.length === 2; },
       function(pair) { return [pair[0]]; },
       function(pair) { return [pair[1]]; }
     );
@@ -3136,10 +3139,10 @@ describe('UnaryType', function() {
 
 describe('BinaryType', function() {
 
-  it('is a quinary function', function() {
+  it('is a sexternary function', function() {
     eq(typeof $.BinaryType, 'function');
-    eq($.BinaryType.length, 5);
-    eq($.BinaryType.toString(), 'BinaryType :: String -> String -> (Any -> Boolean) -> (t a b -> Array a) -> (t a b -> Array b) -> Function');
+    eq($.BinaryType.length, 6);
+    eq($.BinaryType.toString(), 'BinaryType :: String -> String -> Type -> (Any -> Boolean) -> (t a b -> Array a) -> (t a b -> Array b) -> Function');
   });
 
   it('returns a type constructor which type checks its arguments', function() {

--- a/test/index.js
+++ b/test/index.js
@@ -131,6 +131,7 @@ function Just(x) { return new _Maybe('Just', x); }
 var Maybe = $.UnaryType(
   'my-package/Maybe',
   'http://example.com/my-package#Maybe',
+  $.Any,
   function(x) { return type(x) === 'my-package/Maybe'; },
   function(maybe) { return maybe.isJust ? [maybe.value] : []; }
 );
@@ -3109,10 +3110,10 @@ describe('NullaryType', function() {
 
 describe('UnaryType', function() {
 
-  it('is a quaternary function', function() {
+  it('is a quinary function', function() {
     eq(typeof $.UnaryType, 'function');
-    eq($.UnaryType.length, 4);
-    eq($.UnaryType.toString(), 'UnaryType :: String -> String -> (Any -> Boolean) -> (t a -> Array a) -> Function');
+    eq($.UnaryType.length, 5);
+    eq($.UnaryType.toString(), 'UnaryType :: String -> String -> Type -> (Any -> Boolean) -> (t a -> Array a) -> Function');
   });
 
   it('returns a type constructor which type checks its arguments', function() {

--- a/test/index.js
+++ b/test/index.js
@@ -1210,6 +1210,9 @@ describe('def', function() {
     //  Point :: Type
     var Point = $.RecordType($.Any, {x: $.Number, y: $.Number});
 
+    //  Point3D :: Type
+    var Point3D = $.RecordType(Point, {z: $.Number});
+
     //  Line :: Type
     var Line = $.RecordType($.Any, {start: Point, end: Point});
 
@@ -1224,12 +1227,17 @@ describe('def', function() {
     });
 
     eq(dist({x: 0, y: 0}, {x: 0, y: 0}), 0);
-    eq(dist({x: 0, y: 0}, {x: 0, y: 0, color: 'red'}), 0);
+    eq(dist({x: 0, y: 0}, {x: 0, y: 0, z: 0}), 0);
     eq(dist({x: 1, y: 1}, {x: 4, y: 5}), 5);
-    eq(dist({x: 1, y: 1}, {x: 4, y: 5, color: 'red'}), 5);
+    eq(dist({x: 1, y: 1}, {x: 4, y: 5, z: 6}), 5);
 
     eq(length({start: {x: 1, y: 1}, end: {x: 4, y: 5}}), 5);
-    eq(length({start: {x: 1, y: 1}, end: {x: 4, y: 5, color: 'red'}}), 5);
+    eq(length({start: {x: 1, y: 1}, end: {x: 4, y: 5, z: 6}}), 5);
+
+    eq($.test([], Point3D, {x: 0, y: 0}), false);
+    eq($.test([], Point3D, {x: 0, z: 0}), false);
+    eq($.test([], Point3D, {y: 0, z: 0}), false);
+    eq($.test([], Point3D, {x: 0, y: 0, z: 0}), true);
 
     throws(function() { dist(null); },
            TypeError,

--- a/test/index.js
+++ b/test/index.js
@@ -240,13 +240,13 @@ describe('create', function() {
            TypeError,
            'Invalid value\n' +
            '\n' +
-           'create :: { checkTypes :: Boolean, env :: Array Any } -> Function\n' +
-           '          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n' +
+           'create :: { checkTypes :: Boolean, env :: Array Type } -> Function\n' +
+           '          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n' +
            '                               1\n' +
            '\n' +
            '1)  true :: Boolean\n' +
            '\n' +
-           'The value at position 1 is not a member of ‘{ checkTypes :: Boolean, env :: Array Any }’.\n');
+           'The value at position 1 is not a member of ‘{ checkTypes :: Boolean, env :: Array Type }’.\n');
   });
 
 });

--- a/test/index.js
+++ b/test/index.js
@@ -1357,6 +1357,22 @@ describe('def', function() {
            'Since there is no type of which all the above values are members, the type-variable constraint has been violated.\n');
   });
 
+  it('supports "strict" record types', function() {
+
+    //  Point :: Type
+    var Point = $.RecordType($.Any, {x: $.Number, y: $.Number});
+
+    //  StrictPoint :: Type
+    var StrictPoint = $.Strict(Point);
+
+    //  p :: Point
+    var p = {x: 1, y: 2, z: 3};
+
+    eq($.test([], Point, p), true);
+    eq($.test([], StrictPoint, p), false);
+
+  });
+
   it('supports "nullable" types', function() {
     eq(typeof $.Nullable, 'function');
     eq($.Nullable.length, 1);


### PR DESCRIPTION
Refinement support:

- [x] NullaryType
- [x] UnaryType
- [x] BinaryType
- [x] RecordType
- [ ] EnumType

Helpers:

- [x] Strict
- [ ] NonEmpty

Fixes #128 
Fixes #141 
Contributes to sanctuary-js/sanctuary#384