### PR TITLE
replace Unknowns with free type variables in string representations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ lint:
 	  --global require \
 	  --global self \
 	  --rule 'max-len: [error, {code: 79, ignorePattern: "^ *//(# |[.] // |[.]   - <code>)", ignoreUrls: true}]' \
+	  --rule 'no-plusplus: [off]' \
 	  -- index.js
 	$(ESLINT) \
 	  --env es6 \


### PR DESCRIPTION
Commit message:

> Currently `???` is used for both Inconsistent and Unknown:
>
>     ['foo', true, 42] :: Array ???
>     []                :: Array ???
>
> This commit visually differentiates the two types:
>
>     ['foo', true, 42] :: Array ???
>     []                :: Array a
>
> The type variable is chosen to avoid collisions with variables in the corresponding type signature.

This pull request was motivated by comments in #160.
