### PR TITLE
types: define NonNegativeInteger

### DIFF
--- a/index.js
+++ b/index.js
@@ -617,6 +617,15 @@
     function(x) { return RegExp_._test(x) && !x.global; }
   );
 
+  //# NonNegativeInteger :: Type
+  //.
+  //. Type comprising every non-negative [`Integer`][] value (including `-0`).
+  //. Also known as the set of natural numbers under ISO 80000-2:2009.
+  var NonNegativeInteger = NullaryTypeWithUrl(
+    'sanctuary-def/NonNegativeInteger',
+    function(x) { return Integer._test(x) && x >= 0; }
+  );
+
   //# NonZeroFiniteNumber :: Type
   //.
   //. Type comprising every [`FiniteNumber`][] value except `0` and `-0`.
@@ -2580,6 +2589,7 @@
     NegativeNumber: NegativeNumber,
     NonEmpty: NonEmpty,
     NonGlobalRegExp: NonGlobalRegExp,
+    NonNegativeInteger: NonNegativeInteger,
     NonZeroFiniteNumber: NonZeroFiniteNumber,
     NonZeroInteger: NonZeroInteger,
     NonZeroValidNumber: NonZeroValidNumber,

--- a/test/index.js
+++ b/test/index.js
@@ -1733,6 +1733,21 @@ describe('def', function() {
     eq(isNonZeroInteger(new Number(1)), false);
   });
 
+  it('provides the "NonNegativeInteger" type', function() {
+    eq($.NonNegativeInteger.name, 'sanctuary-def/NonNegativeInteger');
+    eq($.NonNegativeInteger.url, 'https://github.com/sanctuary-js/sanctuary-def/tree/v' + version + '#NonNegativeInteger');
+
+    function isNonNegativeInteger(x) {
+      return $.test($.env, $.NonNegativeInteger, x);
+    }
+    eq(isNonNegativeInteger(0), true);
+    eq(isNonNegativeInteger(-0), true);
+    eq(isNonNegativeInteger(1), true);
+    eq(isNonNegativeInteger(-1), false);
+    eq(isNonNegativeInteger(3.14), false);
+    eq(isNonNegativeInteger(new Number(1)), false);
+  });
+
   it('provides the "PositiveInteger" type', function() {
     eq($.PositiveInteger.name, 'sanctuary-def/PositiveInteger');
     eq($.PositiveInteger.url, 'https://github.com/sanctuary-js/sanctuary-def/tree/v' + version + '#PositiveInteger');


### PR DESCRIPTION
I'm not able to run `make test lint` on my PC yet. The change is small and atomic, and I ran my tests for the new type using another method.

I'm unsure about the right way to treat `-0`. `$test( [], NonNegativeInteger, -0 )` returns `true`. I included a test for this in the test suite to make that clear.

The other candidate name for this Type is `NaturalNumber`. Unfortunately, there seems to be a good deal of controversy over whether zero is included in the set of natural numbers.