### PR TITLE
fix underlining of unary and binary type variables

### DIFF
--- a/index.js
+++ b/index.js
@@ -1076,13 +1076,12 @@
             return function(propPath) {
               var indexedPropPath = Z.concat([index], propPath);
               return function(s) {
-                if (t.type === VARIABLE && isEmpty(t.keys)) {
+                if (paths.some(isPrefix(indexedPropPath))) {
                   var key = JSON.stringify(indexedPropPath);
-                  var exists = hasOwnProperty.call(valuesByPath, key);
-                  return (exists && !isEmpty(valuesByPath[key]) ? f : _)(s);
-                } else {
-                  return unless(paths.some(isPrefix(indexedPropPath)), _, s);
+                  if (!hasOwnProperty.call(valuesByPath, key)) return s;
+                  if (!isEmpty(valuesByPath[key])) return f(s);
                 }
+                return _(s);
               };
             };
           };

--- a/test/index.js
+++ b/test/index.js
@@ -3029,7 +3029,7 @@ describe('def', function() {
   });
 
   it('supports binary type variables', function() {
-    var env = $.env.concat([$Pair($.Unknown, $.Unknown)]);
+    var env = $.env.concat([Either($.Unknown, $.Unknown), Maybe($.Unknown), $Pair($.Unknown, $.Unknown)]);
     var def = $.create({checkTypes: true, env: env});
 
     //  f :: (Type, Type) -> Type
@@ -3054,6 +3054,23 @@ describe('def', function() {
            '                                                  1\n' +
            '\n' +
            '1)  ["foo", true, 42] :: Array ???\n' +
+           '\n' +
+           'Since there is no type of which all the above values are members, the type-variable constraint has been violated.\n');
+
+    //  chain :: Chain m => (a -> m b) -> m a -> m b
+    var chain = def('chain', {m: [Z.Chain]}, [$.Function([a, m(b)]), m(a), m(b)], Z.chain);
+
+    throws(function() { chain(Left, Just('x')); },
+           TypeError,
+           'Type-variable constraint violation\n' +
+           '\n' +
+           'chain :: Chain m => (a -> m b) -> m a -> m b\n' +
+           '                          ^^^     ^^^\n' +
+           '                           1       2\n' +
+           '\n' +
+           '1)  Left("x") :: Either String c\n' +
+           '\n' +
+           '2)  Just("x") :: Maybe String\n' +
            '\n' +
            'Since there is no type of which all the above values are members, the type-variable constraint has been violated.\n');
   });


### PR DESCRIPTION
Fixes #166

The good news, @dakom, is that the current version of sanctuary-def does detect the type error in the aforementioned issue. Upgrading to the latest sanctuary-def release would only be a partial fix, though, as error messages would lack the helpful `^^^` markers due to a bug in `underlineTypeVars` (which this pull request fixes).

After merging this we can publish a patch release then have Sanctuary depend on the new version.
