### PR TITLE
disable type checking for $ functions in "production"

### DIFF
--- a/index.js
+++ b/index.js
@@ -867,7 +867,15 @@
   //  Unchecked :: String -> Type
   function Unchecked(s) { return NullaryType(s)('')(K(true)); }
 
-  var def = _create({checkTypes: true, env: env});
+  //  production :: Boolean
+  var production =
+    typeof process !== 'undefined' &&
+    /* global process:false */
+    process != null &&
+    process.env != null &&
+    process.env.NODE_ENV === 'production';
+
+  var def = _create({checkTypes: !production, env: env});
 
   //  numbers :: Array String
   var numbers = [

--- a/test/NODE_ENV.js
+++ b/test/NODE_ENV.js
@@ -1,0 +1,93 @@
+'use strict';
+
+const fs = require ('fs');
+const path = require ('path');
+const vm = require ('vm');
+
+const version = (require ('../package.json')).version;
+const throws = require ('./internal/throws');
+
+
+suite ('NODE_ENV', () => {
+
+  const source = fs.readFileSync (path.join (__dirname, '..', 'index.js'), 'utf8');
+
+  const invalid = new TypeError (`Invalid value
+
+NullaryType :: String -> String -> (Any -> Boolean) -> Type
+               ^^^^^^
+                 1
+
+1)  null :: Null
+
+The value at position 1 is not a member of ‘String’.
+
+See https://github.com/sanctuary-js/sanctuary-def/tree/v${version}#String for information about the String type.
+`);
+
+  test ('typeof process === "undefined"', () => {
+    const context = {
+      module: {exports: {}},
+      require: require,
+    };
+    vm.runInNewContext (source, context);
+
+    throws (() => { context.module.exports.NullaryType (null); }) (invalid);
+  });
+
+  test ('typeof process !== "undefined" && process == null', () => {
+    const context = {
+      module: {exports: {}},
+      process: null,
+      require: require,
+    };
+    vm.runInNewContext (source, context);
+
+    throws (() => { context.module.exports.NullaryType (null); }) (invalid);
+  });
+
+  test ('typeof process !== "undefined" && process != null && process.env == null', () => {
+    const context = {
+      module: {exports: {}},
+      process: {},
+      require: require,
+    };
+    vm.runInNewContext (source, context);
+
+    throws (() => { context.module.exports.NullaryType (null); }) (invalid);
+  });
+
+  test ('typeof process !== "undefined" && process != null && process.env != null && process.env.NODE_ENV == null', () => {
+    const context = {
+      module: {exports: {}},
+      process: {env: {}},
+      require: require,
+    };
+    vm.runInNewContext (source, context);
+
+    throws (() => { context.module.exports.NullaryType (null); }) (invalid);
+  });
+
+  test ('typeof process !== "undefined" && process != null && process.env != null && process.env.NODE_ENV !== "production"', () => {
+    const context = {
+      module: {exports: {}},
+      process: {env: {NODE_ENV: 'XXX'}},
+      require: require,
+    };
+    vm.runInNewContext (source, context);
+
+    throws (() => { context.module.exports.NullaryType (null); }) (invalid);
+  });
+
+  test ('typeof process !== "undefined" && process != null && process.env != null && process.env.NODE_ENV === "production"', () => {
+    const context = {
+      module: {exports: {}},
+      process: {env: {NODE_ENV: 'production'}},
+      require: require,
+    };
+    vm.runInNewContext (source, context);
+
+    context.module.exports.NullaryType (null);
+  });
+
+});

--- a/test/index.js
+++ b/test/index.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const assert = require ('assert');
 const vm = require ('vm');
 
 const Z = require ('sanctuary-type-classes');
@@ -9,6 +8,9 @@ const type = require ('sanctuary-type-identifiers');
 
 const $ = require ('..');
 
+const eq = require ('./internal/eq');
+const throws = require ('./internal/throws');
+
 
 //    curry2 :: ((a, b) -> c) -> a -> b -> c
 const curry2 = f => x => y => f (x, y);
@@ -16,27 +18,8 @@ const curry2 = f => x => y => f (x, y);
 //    curry3 :: ((a, b, c) -> d) -> a -> b -> c -> d
 const curry3 = f => x => y => z => f (x, y, z);
 
-//    eq :: a -> b -> Undefined !
-function eq(actual) {
-  assert.strictEqual (arguments.length, eq.length);
-  return function eq$1(expected) {
-    assert.strictEqual (arguments.length, eq$1.length);
-    assert.strictEqual (Z.toString (actual), Z.toString (expected));
-    assert.strictEqual (Z.equals (actual, expected), true);
-  };
-}
-
 //    notImplemented :: () -> Undefined !
 const notImplemented = () => { throw new Error ('Not implemented'); };
-
-//    throws :: (() -> Undefined !) -> Error -> Undefined !
-function throws(thunk) {
-  assert.strictEqual (arguments.length, throws.length);
-  return function throws$1(expected) {
-    assert.strictEqual (arguments.length, throws$1.length);
-    assert.throws (thunk, actual => Z.equals (actual, expected));
-  };
-}
 
 //    version :: String
 const version = '0.14.0';  // updated programmatically

--- a/test/internal/eq.js
+++ b/test/internal/eq.js
@@ -1,0 +1,16 @@
+'use strict';
+
+const assert = require ('assert');
+
+const Z = require ('sanctuary-type-classes');
+
+
+//    eq :: a -> b -> Undefined !
+module.exports = function eq(actual) {
+  assert.strictEqual (arguments.length, eq.length);
+  return function eq$1(expected) {
+    assert.strictEqual (arguments.length, eq$1.length);
+    assert.strictEqual (Z.toString (actual), Z.toString (expected));
+    assert.strictEqual (Z.equals (actual, expected), true);
+  };
+};

--- a/test/internal/throws.js
+++ b/test/internal/throws.js
@@ -1,0 +1,15 @@
+'use strict';
+
+const assert = require ('assert');
+
+const Z = require ('sanctuary-type-classes');
+
+
+//    throws :: (() -> Undefined !) -> Error -> Undefined !
+module.exports = function throws(thunk) {
+  assert.strictEqual (arguments.length, throws.length);
+  return function throws$1(expected) {
+    assert.strictEqual (arguments.length, throws$1.length);
+    assert.throws (thunk, actual => Z.equals (actual, expected));
+  };
+};


### PR DESCRIPTION
Accompanies sanctuary-js/sanctuary#512

This pull request only affects the behaviour of `$` functions (such as `$.create` and `$.NullaryType`); functions created via `def` still respect the given `checkTypes` Boolean.
