### PR TITLE
define Type#fantasy-land/equals

### DIFF
--- a/index.js
+++ b/index.js
@@ -361,6 +361,19 @@
 
   _Type['@@type'] = 'sanctuary-def/Type';
 
+  //  Type#fantasy-land/equals :: Type ~> Type -> Boolean
+  _Type.prototype['fantasy-land/equals'] = function(other) {
+    return (
+      Z.equals(this.type, other.type) &&
+      Z.equals(this.name, other.name) &&
+      Z.equals(this.url, other.url) &&
+      Z.equals(this.keys, other.keys) &&
+      this.keys.every(function(k) {
+        return Z.equals(this.types[k].type, other.types[k].type);
+      }, this)
+    );
+  };
+
   _Type.prototype.validate = function(x) {
     if (!this._test(x)) return Left({value: x, propPath: []});
     for (var idx = 0; idx < this.keys.length; idx += 1) {

--- a/test/index.js
+++ b/test/index.js
@@ -3242,3 +3242,26 @@ See https://github.com/sanctuary-js/sanctuary-def/tree/v${version}#Boolean for i
   });
 
 });
+
+suite ('interoperability', () => {
+
+  test ('Z.equals can operate on ‘Type’ values', () => {
+    eq (Z.equals ($.Number, $.Number)) (true);
+    eq (Z.equals ($.Number, $.String)) (false);
+    eq (Z.equals ($.Array ($.Number), $.Array ($.Number))) (true);
+    eq (Z.equals ($.Array ($.Number), $.Array ($.String))) (false);
+    eq (Z.equals ($.RecordType ({x: $.Number}), $.RecordType ({x: $.Number}))) (true);
+    eq (Z.equals ($.RecordType ({x: $.Number}), $.RecordType ({y: $.Number}))) (false);
+    eq (Z.equals ($.RecordType ({x: $.Number}), $.RecordType ({x: $.String}))) (false);
+    eq (Z.equals ($.NullaryType ('X') ('') (x => true), $.NullaryType ('X') ('') (x => true))) (true);
+    eq (Z.equals ($.NullaryType ('X') ('') (x => true), $.NullaryType ('Y') ('') (x => true))) (false);
+    eq (Z.equals ($.NullaryType ('X') ('') (x => true), $.NullaryType ('X') ('') (x => false))) (true);
+    eq (Z.equals ($.Array ($.NullaryType ('X') ('http://x.com/') (x => true)),
+                  $.Array ($.NullaryType ('X') ('http://x.com/') (x => true))))
+       (true);
+    eq (Z.equals ($.Array ($.NullaryType ('X') ('http://x.com/') (x => true)),
+                  $.Array ($.NullaryType ('X') ('http://x.org/') (x => true))))
+       (false);
+  });
+
+});


### PR DESCRIPTION
I'd like to add a doctest for [`S.env`][1] such as this:

```javascript
//. > S.env
//. [ $.AnyFunction,
//. . $.Arguments,
//. . ...
//. . $.ValidDate,
//. . $.ValidNumber ]
```

In order to do so, two things must happen:

  - [`$.Type`][2] must be added to Sanctuary's default environment; and
  - `Type` values must satisfy the Setoid constraint imposed by [`S.equals`][3].


[1]: https://sanctuary.js.org/#env
[2]: https://github.com/sanctuary-js/sanctuary-def#Type
[3]: https://sanctuary.js.org/#equals
