### PR TITLE
do not underline enclosing parentheses

### DIFF
--- a/index.js
+++ b/index.js
@@ -232,6 +232,9 @@
   //  K :: a -> b -> a
   function K(x) { return function(y) { return x; }; }
 
+  //  W :: (a -> a -> b) -> a -> b
+  function W(f) { return function(x) { return f(x)(x); }; }
+
   //  always0 :: a -> () -> a
   function always0(x) { return function() { return x; }; }
 
@@ -2171,14 +2174,19 @@
   ) {
     var st = typeInfo.types.reduce(function(st, t, index) {
       var formatType4 = formatType5(index);
-      var counter = st.counter;
-      function replace(s) { return label(show(counter += 1))(s); }
-      return {
-        carets: Z.concat(st.carets, [_underline(t, [], formatType4(r('^')))]),
-        numbers: Z.concat(st.numbers,
-                          [_underline(t, [], formatType4(replace))]),
-        counter: counter
-      };
+      st.numbers.push(_underline(t, [], formatType4(function(s) {
+        return label(show(st.counter += 1))(s);
+      })));
+      st.carets.push(_underline(t, [], W(function(type) {
+        var repr = show(type);
+        var parenthesized = repr.slice(0, 1) + repr.slice(-1) === '()';
+        return formatType4(function(s) {
+          return parenthesized && repr !== '()' && s.length === repr.length ?
+            _('(') + r('^')(s.slice(1, -1)) + _(')') :
+            r('^')(s);
+        });
+      })));
+      return st;
     }, {carets: [], numbers: [], counter: 0});
 
     return typeSignature(typeInfo) + '\n' +

--- a/test/index.js
+++ b/test/index.js
@@ -2198,7 +2198,7 @@ Since there is no type of which all the above values are members, the type-varia
            (new TypeError (`Invalid value
 
 unnest :: Array (Array a) -> Array a
-                ^^^^^^^^^
+                 ^^^^^^^
                     1
 
 1)  1 :: Number, Integer
@@ -2414,7 +2414,7 @@ Since there is no type of which all the above values are members, the type-varia
            (new TypeError (`Invalid value
 
 g :: (String -> Number) -> Array String -> Array Number
-     ^^^^^^^^^^^^^^^^^^
+      ^^^^^^^^^^^^^^^^
              1
 
 1)  /xxx/ :: RegExp
@@ -2512,7 +2512,7 @@ Since there is no type of which all the above values are members, the type-varia
            (new TypeError (`Invalid value
 
 reduce_ :: ((a, b) -> a) -> a -> Array b -> a
-           ^^^^^^^^^^^^^
+            ^^^^^^^^^^^
                  1
 
 1)  null :: Null
@@ -2544,7 +2544,7 @@ The value at position 1 is not a member of ‘(a, b) -> a’.
            (new TypeError (`Invalid value
 
 unfoldr :: (b -> Maybe (Array2 a b)) -> b -> Array a
-           ^^^^^^^^^^^^^^^^^^^^^^^^^
+            ^^^^^^^^^^^^^^^^^^^^^^^
                        1
 
 1)  null :: Null
@@ -2556,7 +2556,7 @@ The value at position 1 is not a member of ‘b -> Maybe (Array2 a b)’.
            (new TypeError (`Invalid value
 
 unfoldr :: (b -> Maybe (Array2 a b)) -> b -> Array a
-                       ^^^^^^^^^^^^
+                        ^^^^^^^^^^
                             1
 
 1)  1 :: Number
@@ -3001,7 +3001,7 @@ Since there is no type of which all the above values are members, the type-varia
            (new TypeError (`Invalid value
 
 map :: Functor f => (a -> b) -> f a -> f b
-                    ^^^^^^^^
+                     ^^^^^^
                        1
 
 1)  Right (Right (Right (Right (0)))) :: Either c (Either d (Either e (Either g Number)))


### PR DESCRIPTION
This tiny improvement did not necessarily warrant the time required to make it (the code for underlining a portion of a type signature is *very* confusing). :stuck_out_tongue_winking_eye:
