### PR TITLE
use util.inspect.custom in recent versions of Node

### DIFF
--- a/index.js
+++ b/index.js
@@ -210,6 +210,16 @@
   var slice             = Array.prototype.slice;
   var hasOwnProperty    = Object.prototype.hasOwnProperty;
 
+  var inspect = (function() {
+    /* istanbul ignore else */
+    if (typeof module === 'object' && typeof module.exports === 'object') {
+      var util = require ('util');
+      /* istanbul ignore else */
+      if (typeof util.inspect.custom === 'symbol') return util.inspect.custom;
+    }
+    return 'inspect';
+  } ());
+
   //  Left :: a -> Either a b
   var Left = Either.Left;
 
@@ -2539,7 +2549,7 @@
       } :
       wrapNext ({}, [], 0);
 
-    wrapped.inspect = wrapped.toString = always0 (typeSignature (typeInfo));
+    wrapped[inspect] = wrapped.toString = always0 (typeSignature (typeInfo));
 
     return wrapped;
   }

--- a/test/index.js
+++ b/test/index.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const util = require ('util');
 const vm = require ('vm');
 
 const {Left, Right} = require ('sanctuary-either');
@@ -238,7 +239,7 @@ See https://github.com/sanctuary-js/sanctuary-def/tree/v${version}#Function for 
         ([$.Number, $.Number, $.Number])
         (x => y => x + y);
 
-    eq (add.inspect ()) ('add :: Number -> Number -> Number');
+    eq (util.inspect (add)) ('add :: Number -> Number -> Number');
     eq (show (add)) ('add :: Number -> Number -> Number');
 
     eq (show ($0)) ('$0 :: () -> Array a');


### PR DESCRIPTION
[https://nodejs.org/api/deprecations.html][1]:

> ### DEP0079: Custom inspection function on Objects via .inspect()
>
> Type: Runtime
>
> Using a property named `inspect` on an object to specify a custom inspection function for [`util.inspect()`][2] is deprecated. Use [`util.inspect.custom`][3] instead. For backward compatibility with Node.js prior to version 6.4.0, both may be specified.


[1]: https://nodejs.org/api/deprecations.html#deprecations_dep0079_custom_inspection_function_on_objects_via_inspect
[2]: https://nodejs.org/api/util.html#util_util_inspect_object_options
[3]: https://nodejs.org/api/util.html#util_util_inspect_custom
