### PR TITLE
documentation: add missing type to default environment

### DIFF
--- a/index.js
+++ b/index.js
@@ -875,6 +875,7 @@
   //.   - <code>[Boolean](#Boolean)</code>
   //.   - <code>[Date](#Date)</code>
   //.   - <code>[Error](#Error)</code>
+  //.   - <code>[HtmlElement](#HtmlElement)</code>
   //.   - <code>[Null](#Null)</code>
   //.   - <code>[Number](#Number)</code>
   //.   - <code>[Object](#Object)</code>


### PR DESCRIPTION
I forgot to include this addition in #209. Converting this list to a doctest would prevent future omissions.
