### PR TITLE
Function implementation names should equal def's name argument

### DIFF
--- a/index.js
+++ b/index.js
@@ -2572,6 +2572,8 @@
       return function(constraints) {
         return function(expTypes) {
           return function(impl) {
+            Object.defineProperty (impl, 'name', {value: name});
+
             return opts.checkTypes ?
               withTypeChecking (opts.env,
                                 {name: name,


### PR DESCRIPTION
Say you've defined a function as follows:

```javascript
const f = x => y => x  + y
```

When one debugs and prints out `f.name`, console outs `f` too. 

In the other hand, once you wrap a given named function using `def`, JavaScript runtimes won't automatically set the function name anymore and probably one will get an empty string in place of `f.name`.

This change is important since functions typed with `def` aren't anonymous anymore and they can be seen in a given stack trace after some `throw`. If typing isn't enough to locate where's the issue, at least one may be able to review the stack trace and follow the code with this extra detail.