### PR TITLE
support explicit subtyping

### DIFF
--- a/test/NODE_ENV.js
+++ b/test/NODE_ENV.js
@@ -14,7 +14,7 @@ suite ('NODE_ENV', () => {
 
   const invalid = new TypeError (`Invalid value
 
-NullaryType :: String -> String -> (Any -> Boolean) -> Type
+NullaryType :: String -> String -> Array Type -> (Any -> Boolean) -> Type
                ^^^^^^
                  1
 


### PR DESCRIPTION
Before:

```javascript
var FiniteNumber = $.NullaryType
  ('FiniteNumber')
  ('https://github.com/sanctuary-js/sanctuary-def/tree/v0.19.0#FiniteNumber')
  (function(x) { return ValidNumber._test (x) && isFinite (x); });
```

After:

```javascript
var FiniteNumber = $.NullaryType
  ('FiniteNumber')
  ('https://github.com/sanctuary-js/sanctuary-def/tree/v0.19.0#FiniteNumber')
  ([ValidNumber])
  (isFinite);
```

The primary reason for this change is to make defining subtypes more convenient. In the future the relationships this change exposes could be used to make type checking more efficient. If a value is not a member of `$.Number`, say, we know it is not a member of any of the subtypes of `$.Number` either.
