### PR TITLE
types: require records to be object-like

### DIFF
--- a/index.js
+++ b/index.js
@@ -1743,6 +1743,7 @@
     }
 
     function test(x) {
+      if (Object (x) !== x) return false;
       var missing = {};
       keys.forEach (function(k) { missing[k] = k; });
       for (var k in x) delete missing[k];
@@ -1816,6 +1817,7 @@
         }
 
         function test(x) {
+          if (Object (x) !== x) return false;
           var missing = {};
           keys.forEach (function(k) { missing[k] = k; });
           for (var k in x) delete missing[k];

--- a/test/index.js
+++ b/test/index.js
@@ -1007,11 +1007,11 @@ Since there is no type of which all the above values are members, the type-varia
     //    Empty :: Type
     const Empty = $.RecordType ({});
 
-    eq ($.test ([]) (Empty) (null)) (true);
-    eq ($.test ([]) (Empty) (undefined)) (true);
-    eq ($.test ([]) (Empty) (false)) (true);
-    eq ($.test ([]) (Empty) (12.34)) (true);
-    eq ($.test ([]) (Empty) ('xyz')) (true);
+    eq ($.test ([]) (Empty) (null)) (false);
+    eq ($.test ([]) (Empty) (undefined)) (false);
+    eq ($.test ([]) (Empty) (false)) (false);
+    eq ($.test ([]) (Empty) (12.34)) (false);
+    eq ($.test ([]) (Empty) ('xyz')) (false);
     eq ($.test ([]) (Empty) (new Boolean (true))) (true);
     eq ($.test ([]) (Empty) (new Number (12.34))) (true);
     eq ($.test ([]) (Empty) (new String ('xyz'))) (true);
@@ -1264,11 +1264,11 @@ The value at position 1 is not a member of ‘{ length :: a }’.
     //    Empty :: Type
     const Empty = $.NamedRecordType ('my-package/Empty') ('') ({});
 
-    eq ($.test ([]) (Empty) (null)) (true);
-    eq ($.test ([]) (Empty) (undefined)) (true);
-    eq ($.test ([]) (Empty) (false)) (true);
-    eq ($.test ([]) (Empty) (12.34)) (true);
-    eq ($.test ([]) (Empty) ('xyz')) (true);
+    eq ($.test ([]) (Empty) (null)) (false);
+    eq ($.test ([]) (Empty) (undefined)) (false);
+    eq ($.test ([]) (Empty) (false)) (false);
+    eq ($.test ([]) (Empty) (12.34)) (false);
+    eq ($.test ([]) (Empty) ('xyz')) (false);
     eq ($.test ([]) (Empty) (new Boolean (true))) (true);
     eq ($.test ([]) (Empty) (new Number (12.34))) (true);
     eq ($.test ([]) (Empty) (new String ('xyz'))) (true);


### PR DESCRIPTION
This pull request corrects the surprising semantics documented in #239.
