### PR TITLE
types: exclude null and undefined from empty record types

### DIFF
--- a/index.js
+++ b/index.js
@@ -1743,6 +1743,7 @@
     }
 
     function test(x) {
+      if (x == null) return false;
       var missing = {};
       keys.forEach (function(k) { missing[k] = k; });
       for (var k in x) delete missing[k];
@@ -1816,6 +1817,7 @@
         }
 
         function test(x) {
+          if (x == null) return false;
           var missing = {};
           keys.forEach (function(k) { missing[k] = k; });
           for (var k in x) delete missing[k];

--- a/test/index.js
+++ b/test/index.js
@@ -1007,8 +1007,8 @@ Since there is no type of which all the above values are members, the type-varia
     //    Empty :: Type
     const Empty = $.RecordType ({});
 
-    eq ($.test ([]) (Empty) (null)) (true);
-    eq ($.test ([]) (Empty) (undefined)) (true);
+    eq ($.test ([]) (Empty) (null)) (false);
+    eq ($.test ([]) (Empty) (undefined)) (false);
     eq ($.test ([]) (Empty) (false)) (true);
     eq ($.test ([]) (Empty) (12.34)) (true);
     eq ($.test ([]) (Empty) ('xyz')) (true);
@@ -1264,8 +1264,8 @@ The value at position 1 is not a member of ‘{ length :: a }’.
     //    Empty :: Type
     const Empty = $.NamedRecordType ('my-package/Empty') ('') ({});
 
-    eq ($.test ([]) (Empty) (null)) (true);
-    eq ($.test ([]) (Empty) (undefined)) (true);
+    eq ($.test ([]) (Empty) (null)) (false);
+    eq ($.test ([]) (Empty) (undefined)) (false);
     eq ($.test ([]) (Empty) (false)) (true);
     eq ($.test ([]) (Empty) (12.34)) (true);
     eq ($.test ([]) (Empty) ('xyz')) (true);


### PR DESCRIPTION
This pull request corrects the surprising semantics documented in #239, without going as far as #240.
