### PR TITLE
dramatically improve performance of UnaryType and BinaryType

### DIFF
--- a/index.js
+++ b/index.js
@@ -1472,8 +1472,8 @@
       ({})
       ([String_,
         String_,
-        Function_ ([Any, Boolean_]),
-        Function_ ([Unchecked ('t a'), Array_ (Unchecked ('a'))]),
+        Unchecked ('(Any -> Boolean)'),
+        Unchecked ('(t a -> Array a)'),
         AnyFunction])
       (function(name) {
          return B (B (B (def (stripNamespace (name)) ({}) ([Type, Type]))))
@@ -1616,9 +1616,9 @@
       ({})
       ([String_,
         String_,
-        Function_ ([Any, Boolean_]),
-        Function_ ([Unchecked ('t a b'), Array_ (Unchecked ('a'))]),
-        Function_ ([Unchecked ('t a b'), Array_ (Unchecked ('b'))]),
+        Unchecked ('(Any -> Boolean)'),
+        Unchecked ('(t a b -> Array a)'),
+        Unchecked ('(t a b -> Array b)'),
         AnyFunction])
       (function(name) {
          return B (B (B (B (def (stripNamespace (name))


### PR DESCRIPTION
Commit message:

> The predicate and extractor functions provided to the `UnaryType` and `BinaryType` type constructors play an important role in type checking. Each predicate function may be applied hundreds of times when a small program is run. This is not a problem, in and of itself.
>
> If these oft-applied functions are themselves type-checked, though, run-time type checking is significantly more expensive as a result.
>
> This commit disables type checking of predicate and extractor functions.

On my computer, the following program takes about **half a second** to run on this branch compared with about **five seconds** on `master`:

```javascript
const $ = require ('.');

const a = $.TypeVariable ('a');

const xs = []; for (let x = 0; x < 1000; x += 1) xs.push ([[[[[[[[[x]]]]]]]]]);

$.create
  ({checkTypes: true, env: [$.Array ($.Unknown), $.Number]})
  ('I')
  ({})
  ([a, a])
  (x => x)
  (xs);
```

Note that providing `$.env` as the environment does not demonstrate the problem because the version of `$.Array` included in `$.env` is not defined via `def`.
