### PR TITLE
remove type namespaces

### DIFF
--- a/index.js
+++ b/index.js
@@ -348,8 +348,10 @@
   //  q :: String -> String
   var q = wrap ('\u2018') ('\u2019');
 
-  //  stripNamespace :: String -> String
-  function stripNamespace(s) { return s.slice (s.indexOf ('/') + 1); }
+  //  stripNamespace :: TypeClass -> String
+  function stripNamespace(typeClass) {
+    return typeClass.name.slice (typeClass.name.indexOf ('/') + 1);
+  }
 
   var Type$prototype = {
     'constructor': {'@@type': 'sanctuary-def/Type@1'},
@@ -426,6 +428,11 @@
   var NoArguments =
   _Type (NO_ARGUMENTS, '', '', always2 ('()'), K (true), [], {});
 
+  //  isParameterizedType :: Type -> Boolean
+  function isParameterizedType(t) {
+    return t.type === UNARY || t.type === BINARY;
+  }
+
   //  typeEq :: String -> a -> Boolean
   function typeEq(name) {
     return function(x) {
@@ -445,7 +452,7 @@
   function functionUrl(name) {
     var version = '0.19.0';  // updated programmatically
     return 'https://github.com/sanctuary-js/sanctuary-def/tree/v' + version +
-           '#' + stripNamespace (name);
+           '#' + name;
   }
 
   var NullaryTypeWithUrl = Z.ap (NullaryType, functionUrl);
@@ -463,7 +470,7 @@
   //.
   //. Type comprising every JavaScript value.
   var Any = NullaryTypeWithUrl
-    ('sanctuary-def/Any')
+    ('Any')
     (K (true));
 
   //# AnyFunction :: Type
@@ -492,14 +499,14 @@
   //.
   //. Type whose sole member is `[]`.
   var Array0 = NullaryTypeWithUrl
-    ('sanctuary-def/Array0')
+    ('Array0')
     (function(x) { return typeEq ('Array') (x) && x.length === 0; });
 
   //# Array1 :: Type -> Type
   //.
   //. Constructor for singleton Array types.
   var Array1 = UnaryTypeWithUrl
-    ('sanctuary-def/Array1')
+    ('Array1')
     (function(x) { return typeEq ('Array') (x) && x.length === 1; })
     (I);
 
@@ -508,7 +515,7 @@
   //. Constructor for heterogeneous Array types of length 2. `['foo', true]` is
   //. a member of `Array2 String Boolean`.
   var Array2 = BinaryTypeWithUrl
-    ('sanctuary-def/Array2')
+    ('Array2')
     (function(x) { return typeEq ('Array') (x) && x.length === 2; })
     (function(array2) { return [array2[0]]; })
     (function(array2) { return [array2[1]]; });
@@ -531,14 +538,14 @@
   //.
   //. Type comprising every [`Date`][] value except `new Date (NaN)`.
   var ValidDate = NullaryTypeWithUrl
-    ('sanctuary-def/ValidDate')
+    ('ValidDate')
     (function(x) { return Date_._test (x) && !(isNaN (x.valueOf ())); });
 
   //# Either :: Type -> Type -> Type
   //.
   //. [Either][] type constructor.
   var Either_ = BinaryTypeWithUrl
-    ('sanctuary-def/Either')
+    ('Either')
     (typeEq ('sanctuary-either/Either@1'))
     (function(either) { return either.isLeft ? [either.value] : []; })
     (function(either) { return either.isLeft ? [] : [either.value]; });
@@ -599,7 +606,7 @@
   //.
   //. Type comprising every [HTML element][].
   var HtmlElement = NullaryTypeWithUrl
-    ('sanctuary-def/HtmlElement')
+    ('HtmlElement')
     (function(x) {
        return /^\[object HTML.+Element\]$/.test (toString.call (x));
      });
@@ -608,7 +615,7 @@
   //.
   //. [Maybe][] type constructor.
   var Maybe = UnaryTypeWithUrl
-    ('sanctuary-def/Maybe')
+    ('Maybe')
     (typeEq ('sanctuary-maybe/Maybe@1'))
     (function(maybe) { return maybe.isJust ? [maybe.value] : []; });
 
@@ -619,7 +626,7 @@
   //.
   //. The given type must satisfy the [Monoid][] and [Setoid][] specifications.
   var NonEmpty = UnaryTypeWithUrl
-    ('sanctuary-def/NonEmpty')
+    ('NonEmpty')
     (function(x) {
        return Z.Monoid.test (x) &&
               Z.Setoid.test (x) &&
@@ -638,7 +645,7 @@
   //.
   //. Constructor for types that include `null` as a member.
   var Nullable = UnaryTypeWithUrl
-    ('sanctuary-def/Nullable')
+    ('Nullable')
     (K (true))
     (function(nullable) {
        // eslint-disable-next-line eqeqeq
@@ -656,28 +663,28 @@
   //.
   //. Type comprising every [`Number`][] value greater than zero.
   var PositiveNumber = NullaryTypeWithUrl
-    ('sanctuary-def/PositiveNumber')
+    ('PositiveNumber')
     (function(x) { return Number_._test (x) && x > 0; });
 
   //# NegativeNumber :: Type
   //.
   //. Type comprising every [`Number`][] value less than zero.
   var NegativeNumber = NullaryTypeWithUrl
-    ('sanctuary-def/NegativeNumber')
+    ('NegativeNumber')
     (function(x) { return Number_._test (x) && x < 0; });
 
   //# ValidNumber :: Type
   //.
   //. Type comprising every [`Number`][] value except `NaN`.
   var ValidNumber = NullaryTypeWithUrl
-    ('sanctuary-def/ValidNumber')
+    ('ValidNumber')
     (function(x) { return Number_._test (x) && !(isNaN (x)); });
 
   //# NonZeroValidNumber :: Type
   //.
   //. Type comprising every [`ValidNumber`][] value except `0` and `-0`.
   var NonZeroValidNumber = NullaryTypeWithUrl
-    ('sanctuary-def/NonZeroValidNumber')
+    ('NonZeroValidNumber')
     (function(x) { return ValidNumber._test (x) && x !== 0; });
 
   //# FiniteNumber :: Type
@@ -685,28 +692,28 @@
   //. Type comprising every [`ValidNumber`][] value except `Infinity` and
   //. `-Infinity`.
   var FiniteNumber = NullaryTypeWithUrl
-    ('sanctuary-def/FiniteNumber')
+    ('FiniteNumber')
     (function(x) { return ValidNumber._test (x) && isFinite (x); });
 
   //# NonZeroFiniteNumber :: Type
   //.
   //. Type comprising every [`FiniteNumber`][] value except `0` and `-0`.
   var NonZeroFiniteNumber = NullaryTypeWithUrl
-    ('sanctuary-def/NonZeroFiniteNumber')
+    ('NonZeroFiniteNumber')
     (function(x) { return FiniteNumber._test (x) && x !== 0; });
 
   //# PositiveFiniteNumber :: Type
   //.
   //. Type comprising every [`FiniteNumber`][] value greater than zero.
   var PositiveFiniteNumber = NullaryTypeWithUrl
-    ('sanctuary-def/PositiveFiniteNumber')
+    ('PositiveFiniteNumber')
     (function(x) { return FiniteNumber._test (x) && x > 0; });
 
   //# NegativeFiniteNumber :: Type
   //.
   //. Type comprising every [`FiniteNumber`][] value less than zero.
   var NegativeFiniteNumber = NullaryTypeWithUrl
-    ('sanctuary-def/NegativeFiniteNumber')
+    ('NegativeFiniteNumber')
     (function(x) { return FiniteNumber._test (x) && x < 0; });
 
   //# Integer :: Type
@@ -714,7 +721,7 @@
   //. Type comprising every integer in the range
   //. [[`Number.MIN_SAFE_INTEGER`][min] .. [`Number.MAX_SAFE_INTEGER`][max]].
   var Integer = NullaryTypeWithUrl
-    ('sanctuary-def/Integer')
+    ('Integer')
     (function(x) {
        return ValidNumber._test (x) &&
               Math.floor (x) === x &&
@@ -726,7 +733,7 @@
   //.
   //. Type comprising every [`Integer`][] value except `0` and `-0`.
   var NonZeroInteger = NullaryTypeWithUrl
-    ('sanctuary-def/NonZeroInteger')
+    ('NonZeroInteger')
     (function(x) { return Integer._test (x) && x !== 0; });
 
   //# NonNegativeInteger :: Type
@@ -734,21 +741,21 @@
   //. Type comprising every non-negative [`Integer`][] value (including `-0`).
   //. Also known as the set of natural numbers under ISO 80000-2:2009.
   var NonNegativeInteger = NullaryTypeWithUrl
-    ('sanctuary-def/NonNegativeInteger')
+    ('NonNegativeInteger')
     (function(x) { return Integer._test (x) && x >= 0; });
 
   //# PositiveInteger :: Type
   //.
   //. Type comprising every [`Integer`][] value greater than zero.
   var PositiveInteger = NullaryTypeWithUrl
-    ('sanctuary-def/PositiveInteger')
+    ('PositiveInteger')
     (function(x) { return Integer._test (x) && x > 0; });
 
   //# NegativeInteger :: Type
   //.
   //. Type comprising every [`Integer`][] value less than zero.
   var NegativeInteger = NullaryTypeWithUrl
-    ('sanctuary-def/NegativeInteger')
+    ('NegativeInteger')
     (function(x) { return Integer._test (x) && x < 0; });
 
   //# Object :: Type
@@ -768,7 +775,7 @@
   //.
   //. [Pair][] type constructor.
   var Pair = BinaryTypeWithUrl
-    ('sanctuary-def/Pair')
+    ('Pair')
     (typeEq ('sanctuary-pair/Pair@1'))
     (function(pair) { return [pair.fst]; })
     (function(pair) { return [pair.snd]; });
@@ -786,7 +793,7 @@
   //.
   //. See also [`NonGlobalRegExp`][].
   var GlobalRegExp = NullaryTypeWithUrl
-    ('sanctuary-def/GlobalRegExp')
+    ('GlobalRegExp')
     (function(x) { return RegExp_._test (x) && x.global; });
 
   //# NonGlobalRegExp :: Type
@@ -795,7 +802,7 @@
   //.
   //. See also [`GlobalRegExp`][].
   var NonGlobalRegExp = NullaryTypeWithUrl
-    ('sanctuary-def/NonGlobalRegExp')
+    ('NonGlobalRegExp')
     (function(x) { return RegExp_._test (x) && !x.global; });
 
   //# RegexFlags :: Type
@@ -811,7 +818,7 @@
   //.   - `'im'`
   //.   - `'gim'`
   var RegexFlags = EnumTypeWithUrl
-    ('sanctuary-def/RegexFlags')
+    ('RegexFlags')
     (['', 'g', 'i', 'm', 'gi', 'gm', 'im', 'gim']);
 
   //# StrMap :: Type -> Type
@@ -821,7 +828,7 @@
   //. `{foo: 1, bar: 2, baz: 3}`, for example, is a member of `StrMap Number`;
   //. `{foo: 1, bar: 2, baz: 'XXX'}` is not.
   var StrMap = UnaryTypeWithUrl
-    ('sanctuary-def/StrMap')
+    ('StrMap')
     (Object_._test)
     (function(strMap) {
        return Z.reduce (function(xs, x) { xs.push (x); return xs; },
@@ -1297,7 +1304,7 @@
   //. ```javascript
   //. //    NonNegativeInteger :: Type
   //. const NonNegativeInteger = $.NullaryType
-  //.   ('my-package/NonNegativeInteger')
+  //.   ('NonNegativeInteger')
   //.   ('http://example.com/my-package#NonNegativeInteger')
   //.   (x => $.test ([]) ($.Integer) (x) && x >= 0);
   //. ```
@@ -1336,7 +1343,7 @@
   //. ```javascript
   //. //    Integer :: Type
   //. const Integer = $.NullaryType
-  //.   ('my-package/Integer')
+  //.   ('Integer')
   //.   ('http://example.com/my-package#Integer')
   //.   (x => typeof x === 'number' &&
   //.         Math.floor (x) === x &&
@@ -1345,7 +1352,7 @@
   //.
   //. //    NonZeroInteger :: Type
   //. const NonZeroInteger = $.NullaryType
-  //.   ('my-package/NonZeroInteger')
+  //.   ('NonZeroInteger')
   //.   ('http://example.com/my-package#NonZeroInteger')
   //.   (x => $.test ([]) (Integer) (x) && x !== 0);
   //.
@@ -1369,6 +1376,8 @@
   //. //   1)  0.5 :: Number
   //. //
   //. //   The value at position 1 is not a member of ‘Integer’.
+  //. //
+  //. //   See http://example.com/my-package#Integer for information about the Integer type.
   //.
   //. rem (42) (0);
   //. // ! TypeError: Invalid value
@@ -1380,10 +1389,12 @@
   //. //   1)  0 :: Number
   //. //
   //. //   The value at position 1 is not a member of ‘NonZeroInteger’.
+  //. //
+  //. //   See http://example.com/my-package#NonZeroInteger for information about the NonZeroInteger type.
   //. ```
   function NullaryType(name) {
     function format(outer, inner) {
-      return outer (stripNamespace (name));
+      return outer (name);
     }
     return function(url) {
       return function(test) {
@@ -1417,18 +1428,15 @@
   //. const show = require ('sanctuary-show');
   //. const type = require ('sanctuary-type-identifiers');
   //.
-  //. //    maybeTypeIdent :: String
-  //. const maybeTypeIdent = 'my-package/Maybe';
+  //. //    MaybeTypeRep :: TypeRep Maybe
+  //. const MaybeTypeRep = {'@@type': 'my-package/Maybe'};
   //.
   //. //    Maybe :: Type -> Type
   //. const Maybe = $.UnaryType
-  //.   (maybeTypeIdent)
+  //.   ('Maybe')
   //.   ('http://example.com/my-package#Maybe')
-  //.   (x => type (x) === maybeTypeIdent)
+  //.   (x => type (x) === MaybeTypeRep['@@type'])
   //.   (maybe => maybe.isJust ? [maybe.value] : []);
-  //.
-  //. //    MaybeTypeRep :: TypeRep Maybe
-  //. const MaybeTypeRep = {'@@type': maybeTypeIdent};
   //.
   //. //    Nothing :: Maybe a
   //. const Nothing = {
@@ -1479,7 +1487,7 @@
         return function(_1) {
           return function($1) {
             function format(outer, inner) {
-              return outer ('(' + stripNamespace (name) + ' ') +
+              return outer ('(' + name + ' ') +
                      inner ('$1') (show ($1)) +
                      outer (')');
             }
@@ -1528,19 +1536,16 @@
   //. ```javascript
   //. const type = require ('sanctuary-type-identifiers');
   //.
-  //. //    pairTypeIdent :: String
-  //. const pairTypeIdent = 'my-package/Pair';
+  //. //    PairTypeRep :: TypeRep Pair
+  //. const PairTypeRep = {'@@type': 'my-package/Pair'};
   //.
   //. //    $Pair :: Type -> Type -> Type
   //. const $Pair = $.BinaryType
-  //.   (pairTypeIdent)
+  //.   ('Pair')
   //.   ('http://example.com/my-package#Pair')
-  //.   (x => type (x) === pairTypeIdent)
+  //.   (x => type (x) === PairTypeRep['@@type'])
   //.   (({fst}) => [fst])
   //.   (({snd}) => [snd]);
-  //.
-  //. //    PairTypeRep :: TypeRep Pair
-  //. const PairTypeRep = {'@@type': pairTypeIdent};
   //.
   //. //    Pair :: a -> b -> Pair a b
   //. const Pair =
@@ -1556,14 +1561,14 @@
   //.
   //. //    Rank :: Type
   //. const Rank = $.NullaryType
-  //.   ('my-package/Rank')
+  //.   ('Rank')
   //.   ('http://example.com/my-package#Rank')
   //.   (x => typeof x === 'string' &&
   //.         /^(A|2|3|4|5|6|7|8|9|10|J|Q|K)$/.test (x));
   //.
   //. //    Suit :: Type
   //. const Suit = $.NullaryType
-  //.   ('my-package/Suit')
+  //.   ('Suit')
   //.   ('http://example.com/my-package#Suit')
   //.   (x => typeof x === 'string' &&
   //.         /^[\u2660\u2663\u2665\u2666]$/.test (x));
@@ -1591,6 +1596,8 @@
   //. //   1)  "X" :: String
   //. //
   //. //   The value at position 1 is not a member of ‘Rank’.
+  //. //
+  //. //   See http://example.com/my-package#Rank for information about the Rank type.
   //. ```
   function BinaryType(name) {
     return function(url) {
@@ -1600,7 +1607,7 @@
             return function($1) {
               return function($2) {
                 function format(outer, inner) {
-                  return outer ('(' + stripNamespace (name) + ' ') +
+                  return outer ('(' + name + ' ') +
                          inner ('$1') (show ($1)) +
                          outer (' ') +
                          inner ('$2') (show ($2)) +
@@ -1652,7 +1659,7 @@
   //. ```javascript
   //. //    Denomination :: Type
   //. const Denomination = $.EnumType
-  //.   ('my-package/Denomination')
+  //.   ('Denomination')
   //.   ('http://example.com/my-package#Denomination')
   //.   ([10, 20, 50, 100, 200]);
   //. ```
@@ -1766,7 +1773,7 @@
   //. ```javascript
   //. //    Cylinder :: Type
   //. const Cylinder = $.NamedRecordType
-  //.   ('my-package/Cylinder')
+  //.   ('Cylinder')
   //.   ('http://example.com/my-package#Cylinder')
   //.   ({radius: $.PositiveFiniteNumber, height: $.PositiveFiniteNumber});
   //.
@@ -1791,7 +1798,7 @@
   //. //
   //. //   The value at position 1 is not a member of ‘Cylinder’.
   //. //
-  //. //   See http://example.com/my-package#Cylinder for information about the my-package/Cylinder type.
+  //. //   See http://example.com/my-package#Cylinder for information about the Cylinder type.
   //. ```
   function NamedRecordType(name) {
     return function(url) {
@@ -1799,7 +1806,7 @@
         var keys = sortedKeys (fields);
 
         function format(outer, inner) {
-          return outer (stripNamespace (name));
+          return outer (name);
         }
 
         function test(x) {
@@ -2104,9 +2111,7 @@
     (sortedKeys (constraints)).forEach (function(k) {
       var f = inner (k);
       constraints[k].forEach (function(typeClass) {
-        $reprs.push (
-          f (typeClass) (stripNamespace (typeClass.name) + ' ' + k)
-        );
+        $reprs.push (f (typeClass) (stripNamespace (typeClass) + ' ' + k));
       });
     });
     return when ($reprs.length > 0,
@@ -2296,7 +2301,7 @@
       showValuesAndTypes (env, typeInfo, [value], 1) + '\n\n' +
       q (typeInfo.name) + ' requires ' +
       q (expType.name) + ' to satisfy the ' +
-      stripNamespace (typeClass.name) + ' type-class constraint; ' +
+      stripNamespace (typeClass) + ' type-class constraint; ' +
       'the value at position 1 does not.\n' +
       see ('type class', typeClass)
     ));
@@ -2385,7 +2390,7 @@
       showValuesAndTypes (env, typeInfo, [value], 1) + '\n\n' +
       'The value at position 1 is not a member of ' +
       showTypeQuoted (t) + '.\n' +
-      see ('type', t)
+      see (isParameterizedType (t) ? 'type constructor' : 'type', t)
     ));
   }
 
@@ -2612,7 +2617,7 @@
   function fromUncheckedUnaryType(typeConstructor) {
     var t = typeConstructor (Unknown);
     var _1 = t.types.$1.extractor;
-    return def (stripNamespace (t.name))
+    return def (t.name)
                ({})
                ([Type, Type])
                (UnaryType (t.name) (t.url) (t._test) (_1));
@@ -2623,7 +2628,7 @@
     var t = typeConstructor (Unknown) (Unknown);
     var _1 = t.types.$1.extractor;
     var _2 = t.types.$2.extractor;
-    return def (stripNamespace (t.name))
+    return def (t.name)
                ({})
                ([Type, Type, Type])
                (BinaryType (t.name) (t.url) (t._test) (_1) (_2));
@@ -2705,7 +2710,7 @@
             Unchecked ('(t a -> Array a)'),
             Unchecked ('Type -> Type')])
           (function(name) {
-             return B (B (B (def (stripNamespace (name)) ({}) ([Type, Type]))))
+             return B (B (B (def (name) ({}) ([Type, Type]))))
                       (UnaryType (name));
            }),
     BinaryType:
@@ -2718,9 +2723,7 @@
             Unchecked ('(t a b -> Array b)'),
             Unchecked ('Type -> Type -> Type')])
           (function(name) {
-             return B (B (B (B (def (stripNamespace (name))
-                                    ({})
-                                    ([Type, Type, Type])))))
+             return B (B (B (B (def (name) ({}) ([Type, Type, Type])))))
                       (BinaryType (name));
            }),
     EnumType:

--- a/test/index.js
+++ b/test/index.js
@@ -125,7 +125,7 @@ def :: String -> StrMap (Array TypeClass) -> NonEmpty (Array Type) -> Function -
 
 The value at position 1 is not a member of ‘StrMap (Array TypeClass)’.
 
-See https://github.com/sanctuary-js/sanctuary-def/tree/v${version}#StrMap for information about the sanctuary-def/StrMap type.
+See https://github.com/sanctuary-js/sanctuary-def/tree/v${version}#StrMap for information about the StrMap type constructor.
 `));
 
     throws (() => { def ('') ({}) ([]); })
@@ -139,7 +139,7 @@ def :: String -> StrMap (Array TypeClass) -> NonEmpty (Array Type) -> Function -
 
 The value at position 1 is not a member of ‘NonEmpty (Array Type)’.
 
-See https://github.com/sanctuary-js/sanctuary-def/tree/v${version}#NonEmpty for information about the sanctuary-def/NonEmpty type.
+See https://github.com/sanctuary-js/sanctuary-def/tree/v${version}#NonEmpty for information about the NonEmpty type constructor.
 `));
 
     throws (() => { def ('') ({}) ([1, 2, 3]); })
@@ -868,7 +868,7 @@ Since there is no type of which all the above values are members, the type-varia
 
     //    TimeUnit :: Type
     const TimeUnit = $.EnumType
-      ('my-package/TimeUnit')
+      ('TimeUnit')
       ('')
       (['milliseconds', 'seconds', 'minutes', 'hours']);
 
@@ -904,7 +904,7 @@ The value at position 1 is not a member of ‘TimeUnit’.
 
     //    SillyType :: Type
     const SillyType = $.EnumType
-      ('my-package/SillyType')
+      ('SillyType')
       ('')
       (['foo', true, 42]);
 
@@ -1220,10 +1220,10 @@ The value at position 1 is not a member of ‘{ length :: a }’.
     eq (typeof $.NamedRecordType) ('function');
     eq ($.NamedRecordType.length) (1);
     eq (show ($.NamedRecordType)) ('NamedRecordType :: NonEmpty String -> String -> StrMap Type -> Type');
-    eq (show ($.NamedRecordType ('my-package/Circle') ('') ({radius: $.PositiveFiniteNumber}))) ('Circle');
+    eq (show ($.NamedRecordType ('Circle') ('') ({radius: $.PositiveFiniteNumber}))) ('Circle');
 
     //    Empty :: Type
-    const Empty = $.NamedRecordType ('my-package/Empty') ('') ({});
+    const Empty = $.NamedRecordType ('Empty') ('') ({});
 
     eq ($.test ([]) (Empty) (null)) (false);
     eq ($.test ([]) (Empty) (undefined)) (false);
@@ -1236,7 +1236,7 @@ The value at position 1 is not a member of ‘{ length :: a }’.
     eq ($.test ([]) (Empty) ([])) (true);
     eq ($.test ([]) (Empty) ({})) (true);
 
-    throws (() => { $.NamedRecordType ('my-package/Circle') ('') ({radius: Number}); })
+    throws (() => { $.NamedRecordType ('Circle') ('') ({radius: Number}); })
            (new TypeError (`Invalid value
 
 NamedRecordType :: NonEmpty String -> String -> StrMap Type -> Type
@@ -1252,7 +1252,7 @@ See https://github.com/sanctuary-js/sanctuary-def/tree/v${version}#Type for info
 
     //    Circle :: Type
     const Circle = $.NamedRecordType
-      ('my-package/Circle')
+      ('Circle')
       ('http://example.com/my-package#Circle')
       ({radius: $.PositiveFiniteNumber});
 
@@ -1285,7 +1285,7 @@ area :: Circle -> PositiveFiniteNumber
 
 The value at position 1 is not a member of ‘Circle’.
 
-See http://example.com/my-package#Circle for information about the my-package/Circle type.
+See http://example.com/my-package#Circle for information about the Circle type.
 `));
   });
 
@@ -1382,7 +1382,7 @@ Since there is no type of which all the above values are members, the type-varia
   });
 
   test ('provides the "Any" type', () => {
-    eq ($.Any.name) ('sanctuary-def/Any');
+    eq ($.Any.name) ('Any');
     eq ($.Any.url) (`https://github.com/sanctuary-js/sanctuary-def/tree/v${version}#Any`);
   });
 
@@ -1411,7 +1411,7 @@ Since there is no type of which all the above values are members, the type-varia
   });
 
   test ('provides the "Array0" type', () => {
-    eq ($.Array0.name) ('sanctuary-def/Array0');
+    eq ($.Array0.name) ('Array0');
     eq ($.Array0.url) (`https://github.com/sanctuary-js/sanctuary-def/tree/v${version}#Array0`);
 
     const isEmptyArray = $.test ($.env) ($.Array0);
@@ -1425,7 +1425,7 @@ Since there is no type of which all the above values are members, the type-varia
     eq ($.Array1.length) (1);
     eq (show ($.Array1)) ('Array1 :: Type -> Type');
     eq (show ($.Array1 (a))) ('(Array1 a)');
-    eq (($.Array1 (a)).name) ('sanctuary-def/Array1');
+    eq (($.Array1 (a)).name) ('Array1');
     eq (($.Array1 (a)).url) (`https://github.com/sanctuary-js/sanctuary-def/tree/v${version}#Array1`);
 
     const isSingletonStringArray = $.test ($.env) ($.Array1 ($.String));
@@ -1441,7 +1441,7 @@ Since there is no type of which all the above values are members, the type-varia
     eq ($.Array2.length) (1);
     eq (show ($.Array2)) ('Array2 :: Type -> Type -> Type');
     eq (show ($.Array2 (a) (b))) ('(Array2 a b)');
-    eq (($.Array2 (a) (b)).name) ('sanctuary-def/Array2');
+    eq (($.Array2 (a) (b)).name) ('Array2');
     eq (($.Array2 (a) (b)).url) (`https://github.com/sanctuary-js/sanctuary-def/tree/v${version}#Array2`);
 
     //    fst :: Array2 a b -> a
@@ -1464,7 +1464,7 @@ fst :: Array2 a b -> a
 
 The value at position 1 is not a member of ‘Array2 a b’.
 
-See https://github.com/sanctuary-js/sanctuary-def/tree/v${version}#Array2 for information about the sanctuary-def/Array2 type.
+See https://github.com/sanctuary-js/sanctuary-def/tree/v${version}#Array2 for information about the Array2 type constructor.
 `));
   });
 
@@ -1483,7 +1483,7 @@ See https://github.com/sanctuary-js/sanctuary-def/tree/v${version}#Array2 for in
     eq ($.Either.length) (1);
     eq (show ($.Either)) ('Either :: Type -> Type -> Type');
     eq (show ($.Either (a) (b))) ('(Either a b)');
-    eq (($.Either (a) (b)).name) ('sanctuary-def/Either');
+    eq (($.Either (a) (b)).name) ('Either');
     eq (($.Either (a) (b)).url) (`https://github.com/sanctuary-js/sanctuary-def/tree/v${version}#Either`);
 
     const isEitherStringNumber = $.test ($.env) ($.Either ($.String) ($.Number));
@@ -1505,7 +1505,7 @@ See https://github.com/sanctuary-js/sanctuary-def/tree/v${version}#Array2 for in
   });
 
   test ('provides the "HtmlElement" type', () => {
-    eq ($.HtmlElement.name) ('sanctuary-def/HtmlElement');
+    eq ($.HtmlElement.name) ('HtmlElement');
     eq ($.HtmlElement.url) (`https://github.com/sanctuary-js/sanctuary-def/tree/v${version}#HtmlElement`);
   });
 
@@ -1514,7 +1514,7 @@ See https://github.com/sanctuary-js/sanctuary-def/tree/v${version}#Array2 for in
     eq ($.Maybe.length) (1);
     eq (show ($.Maybe)) ('Maybe :: Type -> Type');
     eq (show ($.Maybe (a))) ('(Maybe a)');
-    eq (($.Maybe (a)).name) ('sanctuary-def/Maybe');
+    eq (($.Maybe (a)).name) ('Maybe');
     eq (($.Maybe (a)).url) (`https://github.com/sanctuary-js/sanctuary-def/tree/v${version}#Maybe`);
 
     const isMaybeNumber = $.test ($.env) ($.Maybe ($.Number));
@@ -1525,7 +1525,7 @@ See https://github.com/sanctuary-js/sanctuary-def/tree/v${version}#Array2 for in
   });
 
   test ('provides the "NonEmpty" type constructor', () => {
-    eq (($.NonEmpty ($.String)).name) ('sanctuary-def/NonEmpty');
+    eq (($.NonEmpty ($.String)).name) ('NonEmpty');
     eq (($.NonEmpty ($.String)).url) (`https://github.com/sanctuary-js/sanctuary-def/tree/v${version}#NonEmpty`);
 
     const isNonEmptyIntegerArray = $.test ($.env) ($.NonEmpty ($.Array ($.Integer)));
@@ -1540,7 +1540,7 @@ See https://github.com/sanctuary-js/sanctuary-def/tree/v${version}#Array2 for in
   });
 
   test ('provides the "Nullable" type constructor', () => {
-    eq (($.Nullable (a)).name) ('sanctuary-def/Nullable');
+    eq (($.Nullable (a)).name) ('Nullable');
     eq (($.Nullable (a)).url) (`https://github.com/sanctuary-js/sanctuary-def/tree/v${version}#Nullable`);
   });
 
@@ -1559,7 +1559,7 @@ See https://github.com/sanctuary-js/sanctuary-def/tree/v${version}#Array2 for in
     eq ($.Pair.length) (1);
     eq (show ($.Pair)) ('Pair :: Type -> Type -> Type');
     eq (show ($.Pair (a) (b))) ('(Pair a b)');
-    eq (($.Pair (a) (b)).name) ('sanctuary-def/Pair');
+    eq (($.Pair (a) (b)).name) ('Pair');
     eq (($.Pair (a) (b)).url) (`https://github.com/sanctuary-js/sanctuary-def/tree/v${version}#Pair`);
 
     const isPairStringNumber = $.test ($.env) ($.Pair ($.String) ($.Number));
@@ -1606,7 +1606,7 @@ See https://github.com/sanctuary-js/sanctuary-def/tree/v${version}#Array2 for in
   });
 
   test ('provides the "ValidDate" type', () => {
-    eq ($.ValidDate.name) ('sanctuary-def/ValidDate');
+    eq ($.ValidDate.name) ('ValidDate');
     eq ($.ValidDate.url) (`https://github.com/sanctuary-js/sanctuary-def/tree/v${version}#ValidDate`);
 
     //    sinceEpoch :: ValidDate -> Number
@@ -1627,14 +1627,14 @@ sinceEpoch :: ValidDate -> Number
 
 The value at position 1 is not a member of ‘ValidDate’.
 
-See https://github.com/sanctuary-js/sanctuary-def/tree/v${version}#ValidDate for information about the sanctuary-def/ValidDate type.
+See https://github.com/sanctuary-js/sanctuary-def/tree/v${version}#ValidDate for information about the ValidDate type.
 `));
 
     eq (sinceEpoch (new Date (123456))) (123.456);
   });
 
   test ('provides the "PositiveNumber" type', () => {
-    eq ($.PositiveNumber.name) ('sanctuary-def/PositiveNumber');
+    eq ($.PositiveNumber.name) ('PositiveNumber');
     eq ($.PositiveNumber.url) (`https://github.com/sanctuary-js/sanctuary-def/tree/v${version}#PositiveNumber`);
 
     const isPositiveNumber = $.test ($.env) ($.PositiveNumber);
@@ -1649,7 +1649,7 @@ See https://github.com/sanctuary-js/sanctuary-def/tree/v${version}#ValidDate for
   });
 
   test ('provides the "NegativeNumber" type', () => {
-    eq ($.NegativeNumber.name) ('sanctuary-def/NegativeNumber');
+    eq ($.NegativeNumber.name) ('NegativeNumber');
     eq ($.NegativeNumber.url) (`https://github.com/sanctuary-js/sanctuary-def/tree/v${version}#NegativeNumber`);
 
     const isNegativeNumber = $.test ($.env) ($.NegativeNumber);
@@ -1664,7 +1664,7 @@ See https://github.com/sanctuary-js/sanctuary-def/tree/v${version}#ValidDate for
   });
 
   test ('provides the "ValidNumber" type', () => {
-    eq ($.ValidNumber.name) ('sanctuary-def/ValidNumber');
+    eq ($.ValidNumber.name) ('ValidNumber');
     eq ($.ValidNumber.url) (`https://github.com/sanctuary-js/sanctuary-def/tree/v${version}#ValidNumber`);
 
     const isValidNumber = $.test ($.env) ($.ValidNumber);
@@ -1674,7 +1674,7 @@ See https://github.com/sanctuary-js/sanctuary-def/tree/v${version}#ValidDate for
   });
 
   test ('provides the "NonZeroValidNumber" type', () => {
-    eq ($.NonZeroValidNumber.name) ('sanctuary-def/NonZeroValidNumber');
+    eq ($.NonZeroValidNumber.name) ('NonZeroValidNumber');
     eq ($.NonZeroValidNumber.url) (`https://github.com/sanctuary-js/sanctuary-def/tree/v${version}#NonZeroValidNumber`);
 
     const isNonZeroValidNumber = $.test ($.env) ($.NonZeroValidNumber);
@@ -1685,7 +1685,7 @@ See https://github.com/sanctuary-js/sanctuary-def/tree/v${version}#ValidDate for
   });
 
   test ('provides the "FiniteNumber" type', () => {
-    eq ($.FiniteNumber.name) ('sanctuary-def/FiniteNumber');
+    eq ($.FiniteNumber.name) ('FiniteNumber');
     eq ($.FiniteNumber.url) (`https://github.com/sanctuary-js/sanctuary-def/tree/v${version}#FiniteNumber`);
 
     const isFiniteNumber = $.test ($.env) ($.FiniteNumber);
@@ -1696,7 +1696,7 @@ See https://github.com/sanctuary-js/sanctuary-def/tree/v${version}#ValidDate for
   });
 
   test ('provides the "PositiveFiniteNumber" type', () => {
-    eq ($.PositiveFiniteNumber.name) ('sanctuary-def/PositiveFiniteNumber');
+    eq ($.PositiveFiniteNumber.name) ('PositiveFiniteNumber');
     eq ($.PositiveFiniteNumber.url) (`https://github.com/sanctuary-js/sanctuary-def/tree/v${version}#PositiveFiniteNumber`);
 
     const isPositiveFiniteNumber = $.test ($.env) ($.PositiveFiniteNumber);
@@ -1711,7 +1711,7 @@ See https://github.com/sanctuary-js/sanctuary-def/tree/v${version}#ValidDate for
   });
 
   test ('provides the "NegativeFiniteNumber" type', () => {
-    eq ($.NegativeFiniteNumber.name) ('sanctuary-def/NegativeFiniteNumber');
+    eq ($.NegativeFiniteNumber.name) ('NegativeFiniteNumber');
     eq ($.NegativeFiniteNumber.url) (`https://github.com/sanctuary-js/sanctuary-def/tree/v${version}#NegativeFiniteNumber`);
 
     const isNegativeFiniteNumber = $.test ($.env) ($.NegativeFiniteNumber);
@@ -1726,7 +1726,7 @@ See https://github.com/sanctuary-js/sanctuary-def/tree/v${version}#ValidDate for
   });
 
   test ('provides the "NonZeroFiniteNumber" type', () => {
-    eq ($.NonZeroFiniteNumber.name) ('sanctuary-def/NonZeroFiniteNumber');
+    eq ($.NonZeroFiniteNumber.name) ('NonZeroFiniteNumber');
     eq ($.NonZeroFiniteNumber.url) (`https://github.com/sanctuary-js/sanctuary-def/tree/v${version}#NonZeroFiniteNumber`);
 
     const isNonZeroFiniteNumber = $.test ($.env) ($.NonZeroFiniteNumber);
@@ -1739,7 +1739,7 @@ See https://github.com/sanctuary-js/sanctuary-def/tree/v${version}#ValidDate for
   });
 
   test ('provides the "Integer" type', () => {
-    eq ($.Integer.name) ('sanctuary-def/Integer');
+    eq ($.Integer.name) ('Integer');
     eq ($.Integer.url) (`https://github.com/sanctuary-js/sanctuary-def/tree/v${version}#Integer`);
 
     const isInteger = $.test ($.env) ($.Integer);
@@ -1751,7 +1751,7 @@ See https://github.com/sanctuary-js/sanctuary-def/tree/v${version}#ValidDate for
   });
 
   test ('provides the "NonZeroInteger" type', () => {
-    eq ($.NonZeroInteger.name) ('sanctuary-def/NonZeroInteger');
+    eq ($.NonZeroInteger.name) ('NonZeroInteger');
     eq ($.NonZeroInteger.url) (`https://github.com/sanctuary-js/sanctuary-def/tree/v${version}#NonZeroInteger`);
 
     const isNonZeroInteger = $.test ($.env) ($.NonZeroInteger);
@@ -1763,7 +1763,7 @@ See https://github.com/sanctuary-js/sanctuary-def/tree/v${version}#ValidDate for
   });
 
   test ('provides the "NonNegativeInteger" type', () => {
-    eq ($.NonNegativeInteger.name) ('sanctuary-def/NonNegativeInteger');
+    eq ($.NonNegativeInteger.name) ('NonNegativeInteger');
     eq ($.NonNegativeInteger.url) (`https://github.com/sanctuary-js/sanctuary-def/tree/v${version}#NonNegativeInteger`);
 
     const isNonNegativeInteger = $.test ($.env) ($.NonNegativeInteger);
@@ -1776,7 +1776,7 @@ See https://github.com/sanctuary-js/sanctuary-def/tree/v${version}#ValidDate for
   });
 
   test ('provides the "PositiveInteger" type', () => {
-    eq ($.PositiveInteger.name) ('sanctuary-def/PositiveInteger');
+    eq ($.PositiveInteger.name) ('PositiveInteger');
     eq ($.PositiveInteger.url) (`https://github.com/sanctuary-js/sanctuary-def/tree/v${version}#PositiveInteger`);
 
     const isPositiveInteger = $.test ($.env) ($.PositiveInteger);
@@ -1787,7 +1787,7 @@ See https://github.com/sanctuary-js/sanctuary-def/tree/v${version}#ValidDate for
   });
 
   test ('provides the "NegativeInteger" type', () => {
-    eq ($.NegativeInteger.name) ('sanctuary-def/NegativeInteger');
+    eq ($.NegativeInteger.name) ('NegativeInteger');
     eq ($.NegativeInteger.url) (`https://github.com/sanctuary-js/sanctuary-def/tree/v${version}#NegativeInteger`);
 
     const isNegativeInteger = $.test ($.env) ($.NegativeInteger);
@@ -1798,7 +1798,7 @@ See https://github.com/sanctuary-js/sanctuary-def/tree/v${version}#ValidDate for
   });
 
   test ('provides the "GlobalRegExp" type', () => {
-    eq ($.GlobalRegExp.name) ('sanctuary-def/GlobalRegExp');
+    eq ($.GlobalRegExp.name) ('GlobalRegExp');
     eq ($.GlobalRegExp.url) (`https://github.com/sanctuary-js/sanctuary-def/tree/v${version}#GlobalRegExp`);
 
     const isGlobalRegExp = $.test ($.env) ($.GlobalRegExp);
@@ -1815,7 +1815,7 @@ See https://github.com/sanctuary-js/sanctuary-def/tree/v${version}#ValidDate for
   });
 
   test ('provides the "NonGlobalRegExp" type', () => {
-    eq ($.NonGlobalRegExp.name) ('sanctuary-def/NonGlobalRegExp');
+    eq ($.NonGlobalRegExp.name) ('NonGlobalRegExp');
     eq ($.NonGlobalRegExp.url) (`https://github.com/sanctuary-js/sanctuary-def/tree/v${version}#NonGlobalRegExp`);
 
     const isNonGlobalRegExp = $.test ($.env) ($.NonGlobalRegExp);
@@ -1832,7 +1832,7 @@ See https://github.com/sanctuary-js/sanctuary-def/tree/v${version}#ValidDate for
   });
 
   test ('provides the "RegexFlags" type', () => {
-    eq ($.RegexFlags.name) ('sanctuary-def/RegexFlags');
+    eq ($.RegexFlags.name) ('RegexFlags');
     eq ($.RegexFlags.url) (`https://github.com/sanctuary-js/sanctuary-def/tree/v${version}#RegexFlags`);
 
     const isRegexFlags = $.test ($.env) ($.RegexFlags);
@@ -1857,7 +1857,7 @@ See https://github.com/sanctuary-js/sanctuary-def/tree/v${version}#ValidDate for
     eq ($.StrMap.length) (1);
     eq (show ($.StrMap)) ('StrMap :: Type -> Type');
     eq (show ($.StrMap (a))) ('(StrMap a)');
-    eq (($.StrMap (a)).name) ('sanctuary-def/StrMap');
+    eq (($.StrMap (a)).name) ('StrMap');
     eq (($.StrMap (a)).url) (`https://github.com/sanctuary-js/sanctuary-def/tree/v${version}#StrMap`);
 
     //    id :: a -> a
@@ -2118,7 +2118,7 @@ fromMaybe :: a -> Maybe a -> a
 
 The value at position 1 is not a member of ‘Maybe a’.
 
-See https://github.com/sanctuary-js/sanctuary-def/tree/v${version}#Maybe for information about the sanctuary-def/Maybe type.
+See https://github.com/sanctuary-js/sanctuary-def/tree/v${version}#Maybe for information about the Maybe type constructor.
 `));
 
     //    fst :: Pair a b -> a
@@ -2141,7 +2141,7 @@ fst :: Pair a b -> a
 
 The value at position 1 is not a member of ‘Pair a b’.
 
-See https://github.com/sanctuary-js/sanctuary-def/tree/v${version}#Pair for information about the sanctuary-def/Pair type.
+See https://github.com/sanctuary-js/sanctuary-def/tree/v${version}#Pair for information about the Pair type constructor.
 `));
 
     //    twin :: Pair a a -> Boolean
@@ -2296,7 +2296,7 @@ unnest :: Array (Array a) -> Array a
 
 The value at position 1 is not a member of ‘Array a’.
 
-See https://github.com/sanctuary-js/sanctuary-def/tree/v${version}#Array for information about the Array type.
+See https://github.com/sanctuary-js/sanctuary-def/tree/v${version}#Array for information about the Array type constructor.
 `));
 
     //    concatComplex :: Array (Either String Integer) -> Array (Either String Integer) -> Array (Either String Integer)
@@ -2333,7 +2333,7 @@ concatComplex :: Array (Either String Integer) -> Array (Either String Integer) 
 
 The value at position 1 is not a member of ‘Integer’.
 
-See https://github.com/sanctuary-js/sanctuary-def/tree/v${version}#Integer for information about the sanctuary-def/Integer type.
+See https://github.com/sanctuary-js/sanctuary-def/tree/v${version}#Integer for information about the Integer type.
 `));
 
     throws (() => { concatComplex ([]) ([Left (/xxx/), Right (0), Right (0.1), Right (0.2)]); })
@@ -2361,7 +2361,7 @@ concatComplex :: Array (Either String Integer) -> Array (Either String Integer) 
 
 The value at position 1 is not a member of ‘Integer’.
 
-See https://github.com/sanctuary-js/sanctuary-def/tree/v${version}#Integer for information about the sanctuary-def/Integer type.
+See https://github.com/sanctuary-js/sanctuary-def/tree/v${version}#Integer for information about the Integer type.
 `));
 
     throws (() => { concatComplex ([]) ([]); })
@@ -2648,7 +2648,7 @@ unfoldr :: (b -> Maybe (Array2 a b)) -> b -> Array a
 
 The value at position 1 is not a member of ‘Array2 a b’.
 
-See https://github.com/sanctuary-js/sanctuary-def/tree/v${version}#Array2 for information about the sanctuary-def/Array2 type.
+See https://github.com/sanctuary-js/sanctuary-def/tree/v${version}#Array2 for information about the Array2 type constructor.
 `));
 
     throws (() => { unfoldr (n => n >= 5 ? Nothing : Just ([null, 'XXX'])) (1); })
@@ -2923,7 +2923,7 @@ sum :: Foldable f => f FiniteNumber -> FiniteNumber
 
 The value at position 1 is not a member of ‘FiniteNumber’.
 
-See https://github.com/sanctuary-js/sanctuary-def/tree/v${version}#FiniteNumber for information about the sanctuary-def/FiniteNumber type.
+See https://github.com/sanctuary-js/sanctuary-def/tree/v${version}#FiniteNumber for information about the FiniteNumber type.
 `));
 
     //    sort :: (Ord a, Applicative f, Foldable f, Monoid (f a)) => f a -> f a
@@ -3029,7 +3029,7 @@ Since there is no type of which all the above values are members, the type-varia
 
     //    Void :: Type
     const Void = $.NullaryType
-      ('my-package/Void')
+      ('Void')
       ('http://example.com/my-package#Void')
       (x => { count += 1; return false; });
 
@@ -3138,9 +3138,9 @@ suite ('UnaryType', () => {
   test ('returns a type constructor which type checks its arguments', () => {
     //    MyUnaryType :: Type -> Type
     const MyUnaryType = $.UnaryType
-      ('my-package/MyUnaryType')
+      ('MyUnaryType')
       ('')
-      (x => type (x) === 'my-package/MyUnaryType@1')
+      (x => type (x) === 'MyUnaryType@1')
       (_ => []);
 
     throws (() => { MyUnaryType ({x: $.Number, y: $.Number}); })
@@ -3171,7 +3171,7 @@ suite ('BinaryType', () => {
   test ('returns a type constructor which type checks its arguments', () => {
     //    MyBinaryType :: Type -> Type -> Type
     const MyBinaryType = $.BinaryType
-      ('my-package/MyBinaryType')
+      ('MyBinaryType')
       ('')
       (x => type (x) === 'my-package/MyBinaryType@1')
       (_ => [])
@@ -3301,7 +3301,7 @@ why :: (() -> Integer) -> Integer
 
 The value at position 1 is not a member of ‘Integer’.
 
-See https://github.com/sanctuary-js/sanctuary-def/tree/v${version}#Integer for information about the sanctuary-def/Integer type.
+See https://github.com/sanctuary-js/sanctuary-def/tree/v${version}#Integer for information about the Integer type.
 `));
   });
 


### PR DESCRIPTION
Namespaces permitted the coexistence of types with the same name defined in different packages. The `url` parameter, added in #105, provides another way to ensure this. Let's rely on the `url` parameter to do double duty.

This pull request also tweaks `invalidValue` to use _type constructor_ rather than _type_ if appropriate.
