### PR TITLE
types: define RegexFlags as a subtype of String

### DIFF
--- a/index.js
+++ b/index.js
@@ -482,7 +482,6 @@
   }
 
   var NullaryTypeWithUrl = Z.ap (NullaryType, functionUrl);
-  var EnumTypeWithUrl = Z.ap (EnumType, functionUrl);
   var UnaryTypeWithUrl = Z.ap (UnaryType, functionUrl);
   var BinaryTypeWithUrl = Z.ap (BinaryType, functionUrl);
 
@@ -895,22 +894,6 @@
     ([RegExp_])
     (complement (prop ('global')));
 
-  //# RegexFlags :: Type
-  //.
-  //. Type comprising the canonical RegExp flags:
-  //.
-  //.   - `''`
-  //.   - `'g'`
-  //.   - `'i'`
-  //.   - `'m'`
-  //.   - `'gi'`
-  //.   - `'gm'`
-  //.   - `'im'`
-  //.   - `'gim'`
-  var RegexFlags = EnumTypeWithUrl
-    ('RegexFlags')
-    (['', 'g', 'i', 'm', 'gi', 'gm', 'im', 'gim']);
-
   //# StrMap :: Type -> Type
   //.
   //. Constructor for homogeneous Object types.
@@ -934,6 +917,23 @@
     ('String')
     ([])
     (typeofEq ('string'));
+
+  //# RegexFlags :: Type
+  //.
+  //. Type comprising the canonical RegExp flags:
+  //.
+  //.   - `''`
+  //.   - `'g'`
+  //.   - `'i'`
+  //.   - `'m'`
+  //.   - `'gi'`
+  //.   - `'gm'`
+  //.   - `'im'`
+  //.   - `'gim'`
+  var RegexFlags = NullaryTypeWithUrl
+    ('RegexFlags')
+    ([String_])
+    (function(s) { return /^g?i?m?$/.test (s); });
 
   //# Symbol :: Type
   //.

--- a/test/index.js
+++ b/test/index.js
@@ -1899,7 +1899,7 @@ See https://github.com/sanctuary-js/sanctuary-def/tree/v${version}#ValidDate for
   test ('provides the "RegexFlags" type', () => {
     eq ($.RegexFlags.name) ('RegexFlags');
     eq ($.RegexFlags.url) (`https://github.com/sanctuary-js/sanctuary-def/tree/v${version}#RegexFlags`);
-    eq ($.RegexFlags.supertypes) ([]);
+    eq ($.RegexFlags.supertypes) ([$.String]);
 
     const isRegexFlags = $.test ([]) ($.RegexFlags);
     eq (isRegexFlags ('')) (true);


### PR DESCRIPTION
This makes `$.RegexFlags` more descriptive, and will make it much easier to increase the set of permissible flags (which we should certainly do at some point).
