### PR TITLE
allow extractors to return any foldable structure

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -3344,7 +3344,7 @@ suite ('UnaryType', () => {
   test ('is a quaternary function', () => {
     eq (typeof $.UnaryType) ('function');
     eq ($.UnaryType.length) (1);
-    eq (show ($.UnaryType)) ('UnaryType :: String -> String -> Array Type -> (Any -> Boolean) -> (t a -> Array a) -> Type -> Type');
+    eq (show ($.UnaryType)) ('UnaryType :: Foldable f => String -> String -> Array Type -> (Any -> Boolean) -> (t a -> f a) -> Type -> Type');
   });
 
   test ('returns a type constructor which type checks its arguments', () => {
@@ -3395,7 +3395,7 @@ suite ('BinaryType', () => {
   test ('is a quinary function', () => {
     eq (typeof $.BinaryType) ('function');
     eq ($.BinaryType.length) (1);
-    eq (show ($.BinaryType)) ('BinaryType :: String -> String -> Array Type -> (Any -> Boolean) -> (t a b -> Array a) -> (t a b -> Array b) -> Type -> Type -> Type');
+    eq (show ($.BinaryType)) ('BinaryType :: Foldable f => String -> String -> Array Type -> (Any -> Boolean) -> (t a b -> f a) -> (t a b -> f b) -> Type -> Type -> Type');
   });
 
   test ('returns a type constructor which type checks its arguments', () => {


### PR DESCRIPTION
I realized while working on [sanctuary-list][1] that we need not require an *array* of values specifically. Many algebraic data types are foldable, so in some cases the identity function should be able to serve as an extractor function.

I tried generalizing the code to avoid using `toArray` anywhere, but this proved impractical due to uses of `Z.chain` with functions that always return arrays. The solution is to compose each of the extractors with `toArray`, necessitating very few internal changes.


[1]: https://github.com/sanctuary-js/sanctuary-list
