### PR TITLE
improve performance of NullaryType

### DIFF
--- a/index.js
+++ b/index.js
@@ -2842,7 +2842,7 @@
           ([String_,
             String_,
             Array_ (Type),
-            Function_ ([Any, Boolean_]),
+            Unchecked ('(Any -> Boolean)'),
             Type])
           (NullaryType),
     UnaryType:


### PR DESCRIPTION
This pull request brings `$.NullaryType` into line with `$.UnaryType` and `$.BinaryType`, which as of #244 do not type-check predicate functions.

On my computer, the following program takes about **40 seconds** to run on this branch compared with about **140 seconds** on `master`:

```javascript
'use strict';

const $ = require ('.');

const a = $.TypeVariable ('a');

const zeros = []; for (let x = 0; x < 1e6; x += 1) zeros.push (0);

$.create
  ({checkTypes: true,
    env: [$.Array ($.Unknown),
          $.NullaryType ('Zero') ('') ([]) (x => x === 0)]})
  ('I')
  ({})
  ([a, a])
  (x => x)
  (zeros);
```
