### PR TITLE
types: define Identity type constructor

### DIFF
--- a/index.js
+++ b/index.js
@@ -697,6 +697,15 @@
        return /^\[object HTML.+Element\]$/.test (toString.call (x));
      });
 
+  //# Identity :: Type -> Type
+  //.
+  //. [Identity][] type constructor.
+  var Identity = UnaryTypeWithUrl
+    ('Identity')
+    ([])
+    (typeEq ('sanctuary-identity/Identity@1'))
+    (I);
+
   //# Maybe :: Type -> Type
   //.
   //. [Maybe][] type constructor.
@@ -1000,6 +1009,7 @@
   //.   - <code>[Either](#Either) ([Unknown][]) ([Unknown][])</code>
   //.   - <code>[Error](#Error)</code>
   //.   - <code>[HtmlElement](#HtmlElement)</code>
+  //.   - <code>[Identity](#Identity) ([Unknown][])</code>
   //.   - <code>[Maybe](#Maybe) ([Unknown][])</code>
   //.   - <code>[Null](#Null)</code>
   //.   - <code>[Number](#Number)</code>
@@ -1020,6 +1030,7 @@
     Either_ (Unknown) (Unknown),
     Error_,
     HtmlElement,
+    Identity (Unknown),
     Maybe (Unknown),
     Null,
     Number_,
@@ -2801,6 +2812,7 @@
     Error: Error_,
     Function: def ('Function') ({}) ([Array_ (Type), Type]) (Function_),
     HtmlElement: HtmlElement,
+    Identity: fromUncheckedUnaryType (Identity),
     Maybe: fromUncheckedUnaryType (Maybe),
     NonEmpty: NonEmpty,
     Null: Null,
@@ -2939,6 +2951,7 @@
 //. [Either]:               v:sanctuary-js/sanctuary-either
 //. [FL:Semigroup]:         https://github.com/fantasyland/fantasy-land#semigroup
 //. [HTML element]:         https://developer.mozilla.org/en-US/docs/Web/HTML/Element
+//. [Identity]:             v:sanctuary-js/sanctuary-identity
 //. [Maybe]:                v:sanctuary-js/sanctuary-maybe
 //. [Monoid]:               https://github.com/fantasyland/fantasy-land#monoid
 //. [Pair]:                 v:sanctuary-js/sanctuary-pair

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "devDependencies": {
     "sanctuary-descending": "1.1.0",
+    "sanctuary-identity": "1.1.0",
     "sanctuary-maybe": "1.1.0",
     "sanctuary-pair": "1.1.0",
     "sanctuary-scripts": "3.2.x"

--- a/test/index.js
+++ b/test/index.js
@@ -5,6 +5,7 @@ const vm = require ('vm');
 
 const Descending = require ('sanctuary-descending');
 const {Left, Right} = require ('sanctuary-either');
+const Identity = require ('sanctuary-identity');
 const {Nothing, Just} = require ('sanctuary-maybe');
 const Pair = require ('sanctuary-pair');
 const show = require ('sanctuary-show');
@@ -1559,6 +1560,20 @@ See https://github.com/sanctuary-js/sanctuary-def/tree/v${version}#Array2 for in
     eq ($.HtmlElement.name) ('HtmlElement');
     eq ($.HtmlElement.url) (`https://github.com/sanctuary-js/sanctuary-def/tree/v${version}#HtmlElement`);
     eq ($.HtmlElement.supertypes) ([]);
+  });
+
+  test ('provides the "Identity" type constructor', () => {
+    eq (typeof $.Identity) ('function');
+    eq ($.Identity.length) (1);
+    eq (show ($.Identity)) ('Identity :: Type -> Type');
+    eq (show ($.Identity (a))) ('(Identity a)');
+    eq (($.Identity (a)).name) ('Identity');
+    eq (($.Identity (a)).url) (`https://github.com/sanctuary-js/sanctuary-def/tree/v${version}#Identity`);
+
+    const isIdentityString = $.test ([]) ($.Identity ($.String));
+    eq (isIdentityString (null)) (false);
+    eq (isIdentityString (Identity (12.34))) (false);
+    eq (isIdentityString (Identity ('abc'))) (true);
   });
 
   test ('provides the "Maybe" type constructor', () => {


### PR DESCRIPTION
`Identity ???` is included in `$.env` so the default Sanctuary module will accept `Identity a` values.
