### PR TITLE
fix underlining of higher-order functions

### DIFF
--- a/index.js
+++ b/index.js
@@ -242,9 +242,6 @@
   //  K :: a -> b -> a
   function K(x) { return function(y) { return x; }; }
 
-  //  W :: (a -> a -> b) -> a -> b
-  function W(f) { return function(x) { return f (x) (x); }; }
-
   //  always0 :: a -> () -> a
   function always0(x) { return function() { return x; }; }
 
@@ -2359,18 +2356,14 @@
     // :: Integer -> (String -> String) -> Type -> PropPath -> String -> String
   ) {
     var st = typeInfo.types.reduce (function(st, t, index) {
-      var formatType4 = formatType5 (index);
-      function f(g) {
-        return function(type) {
-          return B (B (B (when (type.type === FUNCTION)
-                               (parenthesize (_)))))
-                   (formatType4 (g));
-        };
-      }
-      st.carets.push (_underline (t, [], W (f (r ('^')))));
-      st.numbers.push (_underline (t, [], W (f (function(s) {
+      var f = B (when (t.type === FUNCTION)
+                      (parenthesize (_)))
+                (B (function(f) { return _underline (t, [], f); })
+                   (formatType5 (index)));
+      st.carets.push (f (r ('^')));
+      st.numbers.push (f (function(s) {
         return label (show (st.counter += 1)) (s);
-      }))));
+      }));
       return st;
     }, {carets: [], numbers: [], counter: 0});
 

--- a/test/index.js
+++ b/test/index.js
@@ -2825,6 +2825,42 @@ T :: a -> (a -> b) -> b
 
 Expected one argument but received zero arguments.
 `));
+
+    throws (() => { def ('once') ({}) ([$.Fn (a) (b), a, b]) (f => x => f (x)) (null); })
+           (new TypeError (`Invalid value
+
+once :: (a -> b) -> a -> b
+         ^^^^^^
+           1
+
+1)  null :: Null
+
+The value at position 1 is not a member of ‘a -> b’.
+`));
+
+    throws (() => { def ('twice') ({}) ([$.Fn (a) ($.Fn (a) (b)), a, b]) (f => x => f (x) (x)) (null); })
+           (new TypeError (`Invalid value
+
+twice :: (a -> a -> b) -> a -> b
+          ^^^^^^^^^^^
+               1
+
+1)  null :: Null
+
+The value at position 1 is not a member of ‘a -> a -> b’.
+`));
+
+    throws (() => { def ('thrice') ({}) ([$.Fn (a) ($.Fn (a) ($.Fn (a) (b))), a, b]) (f => x => f (x) (x) (x)) (null); })
+           (new TypeError (`Invalid value
+
+thrice :: (a -> a -> a -> b) -> a -> b
+           ^^^^^^^^^^^^^^^^
+                  1
+
+1)  null :: Null
+
+The value at position 1 is not a member of ‘a -> a -> a -> b’.
+`));
   });
 
   test ('supports type-class constraints', () => {


### PR DESCRIPTION
Before:

```
once :: (a -> b) -> a -> b
         ^^^^^^
           1
```

```
twice :: (a -> a -> b) -> a -> b
          ^^^^^^^^^^^^^
                1
```

```
thrice :: (a -> a -> a -> b) -> a -> b
           ^^^^^^^^^^^^^^^^^^^^
                    1
```

After:

```
once :: (a -> b) -> a -> b
         ^^^^^^
           1
```

```
twice :: (a -> a -> b) -> a -> b
          ^^^^^^^^^^^
               1
```

```
thrice :: (a -> a -> a -> b) -> a -> b
           ^^^^^^^^^^^^^^^^
                  1
```
