### PR TITLE
types: define JsSet and JsMap type constructors

### DIFF
--- a/index.js
+++ b/index.js
@@ -710,6 +710,21 @@
     (typeEq ('sanctuary-identity/Identity@1'))
     (I);
 
+  //# JsMap :: Type -> Type -> Type
+  var JsMap = BinaryTypeWithUrl
+    ('JsMap')
+    ([])
+    (function(x) { return toString.call (x) === '[object Map]'; })
+    (function(jsMap) { return Array.from (jsMap.keys ()); })
+    (function(jsMap) { return Array.from (jsMap.values ()); });
+
+  //# JsSet :: Type -> Type
+  var JsSet = UnaryTypeWithUrl
+    ('JsSet')
+    ([])
+    (function(x) { return toString.call (x) === '[object Set]'; })
+    (function(jsSet) { return Array.from (jsSet.values ()); });
+
   //# Maybe :: Type -> Type
   //.
   //. [Maybe][] type constructor.
@@ -1016,6 +1031,8 @@
   //.   - <code>[Fn](#Fn) ([Unknown][]) ([Unknown][])</code>
   //.   - <code>[HtmlElement](#HtmlElement)</code>
   //.   - <code>[Identity](#Identity) ([Unknown][])</code>
+  //.   - <code>[JsMap](#JsMap) ([Unknown][]) ([Unknown][])</code>
+  //.   - <code>[JsSet](#JsSet) ([Unknown][])</code>
   //.   - <code>[Maybe](#Maybe) ([Unknown][])</code>
   //.   - <code>[Null](#Null)</code>
   //.   - <code>[Number](#Number)</code>
@@ -1041,6 +1058,8 @@
     Fn (Unknown) (Unknown),
     HtmlElement,
     Identity (Unknown),
+    JsMap (Unknown) (Unknown),
+    JsSet (Unknown),
     Maybe (Unknown),
     Null,
     Number_,
@@ -2789,6 +2808,8 @@
           (Function_),
     HtmlElement: HtmlElement,
     Identity: fromUncheckedUnaryType (Identity),
+    JsMap: fromUncheckedBinaryType (JsMap),
+    JsSet: fromUncheckedUnaryType (JsSet),
     Maybe: fromUncheckedUnaryType (Maybe),
     NonEmpty: NonEmpty,
     Null: Null,

--- a/test/index.js
+++ b/test/index.js
@@ -1619,6 +1619,40 @@ See https://github.com/sanctuary-js/sanctuary-def/tree/v${version}#Array2 for in
     eq (isIdentityString (Identity ('abc'))) (true);
   });
 
+  test ('provides the "JsMap" type constructor', () => {
+    eq (typeof $.JsMap) ('function');
+    eq ($.JsMap.length) (1);
+    eq (show ($.JsMap)) ('JsMap :: Type -> Type -> Type');
+    eq (show ($.JsMap (a) (b))) ('JsMap a b');
+    eq (($.JsMap (a) (b)).name) ('JsMap');
+    eq (($.JsMap (a) (b)).url) (`https://github.com/sanctuary-js/sanctuary-def/tree/v${version}#JsMap`);
+    eq (($.JsMap (a) (b)).supertypes) ([]);
+
+    const isJsMapNumberString = $.test ([]) ($.JsMap ($.Number) ($.String));
+    eq (isJsMapNumberString (null)) (false);
+    eq (isJsMapNumberString ({})) (false);
+    eq (isJsMapNumberString (new Map ([]))) (true);
+    eq (isJsMapNumberString (new Map ([[1, 'a'], [2, 'b'], [3, 'c']]))) (true);
+    eq (isJsMapNumberString (new Map ([['a', 1], ['b', 2], ['c', 3]]))) (false);
+  });
+
+  test ('provides the "JsSet" type constructor', () => {
+    eq (typeof $.JsSet) ('function');
+    eq ($.JsSet.length) (1);
+    eq (show ($.JsSet)) ('JsSet :: Type -> Type');
+    eq (show ($.JsSet (a))) ('JsSet a');
+    eq (($.JsSet (a)).name) ('JsSet');
+    eq (($.JsSet (a)).url) (`https://github.com/sanctuary-js/sanctuary-def/tree/v${version}#JsSet`);
+    eq (($.JsSet (a)).supertypes) ([]);
+
+    const isJsSetNumber = $.test ([]) ($.JsSet ($.Number));
+    eq (isJsSetNumber (null)) (false);
+    eq (isJsSetNumber ([])) (false);
+    eq (isJsSetNumber (new Set ([]))) (true);
+    eq (isJsSetNumber (new Set ([1, 2, 3]))) (true);
+    eq (isJsSetNumber (new Set (['a', 'b', 'c']))) (false);
+  });
+
   test ('provides the "Maybe" type constructor', () => {
     eq (typeof $.Maybe) ('function');
     eq ($.Maybe.length) (1);


### PR DESCRIPTION
Closes #183

I set out to define `$.JsWeakSet` and `$.JsWeakMap` as well, but I decided not to do so when I learnt how strange [`WeakSet`][1] and [`WeakMap`][2] are. Users can define (nullary) types for these if necessary.


[1]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakSet
[2]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakMap
