### PR TITLE
Readme fix (index.js)

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,9 +61,11 @@
 //. const env = $.env.concat ([List ($.Unknown)]);
 //. ```
 //.
-//. The next step is to define a `def` function for the environment:
+//. The next step is to define a `def` function for the environment using
+//. `$.create`:
 //.
 //. ```javascript
+//. //    def :: String -> StrMap (Array TypeClass) -> Array Type -> Function -> Function
 //. const def = $.create ({checkTypes: true, env});
 //. ```
 //.
@@ -72,6 +74,7 @@
 //. during development. For example:
 //.
 //. ```javascript
+//. //    def :: String -> StrMap (Array TypeClass) -> Array Type -> Function -> Function
 //. const def = $.create ({
 //.   checkTypes: process.env.NODE_ENV === 'development',
 //.   env,
@@ -83,10 +86,10 @@
 //. ```javascript
 //. //    add :: Number -> Number -> Number
 //. const add =
-//. def ('add')
-//.     ({})
-//.     ([$.Number, $.Number, $.Number])
-//.     (x => y => x + y);
+//. def ('add')                           // name
+//.     ({})                              // type-class constraints
+//.     ([$.Number, $.Number, $.Number])  // input and output types
+//.     (x => y => x + y);                // implementation
 //. ```
 //.
 //. `[$.Number, $.Number, $.Number]` specifies that `add` takes two arguments


### PR DESCRIPTION
I made an attempt to better clarify the object accepted by the `create` method, the arguments accepted by the returned function (`def`) from the `create` method, added type signatures for both `create` and `def` and commented an example where `def` is used.  All changes are simple and my fp knowledge is limited, but growing :smile:. So please let me what is wrong or feel free to correct anything that is not documented correctly.  Lastly, I could not figure out how you auto generated the docs from the index.js file, so the end result may not be quite right, but all tests are passing.