### PR TITLE
preserve field ordering when formatting record types

### DIFF
--- a/index.js
+++ b/index.js
@@ -411,7 +411,8 @@
         Z.equals (this.name, other.name) &&
         Z.equals (this.url, other.url) &&
         Z.equals (this.supertypes, other.supertypes) &&
-        Z.equals (this.keys, other.keys) &&
+        this.keys.length === other.keys.length &&
+        this.keys.every (function(k) { return other.keys.includes (k); }) &&
         Z.equals (this.types, other.types)
       );
     }
@@ -1917,7 +1918,7 @@
   //. //   The value at position 1 is not a member of ‘{ x :: FiniteNumber, y :: FiniteNumber }’.
   //. ```
   function RecordType(fields) {
-    var keys = sortedKeys (fields);
+    var keys = Object.keys (fields);
 
     function format(outer, inner) {
       if (isEmpty (keys)) return outer ('{}');

--- a/test/index.js
+++ b/test/index.js
@@ -988,11 +988,15 @@ Since there is no type of which all the above values are members, the type-varia
     eq (show ($.RecordType ({}))) ('{}');
     eq (show ($.RecordType ({x: $.Number}))) ('{ x :: Number }');
     eq (show ($.RecordType ({x: $.Number, y: $.Number}))) ('{ x :: Number, y :: Number }');
-    eq (show ($.RecordType ({_ABC: $.Number, $123: $.Number}))) ('{ $123 :: Number, _ABC :: Number }');
+    eq (show ($.RecordType ({_ABC: $.Number, $123: $.Number}))) ('{ _ABC :: Number, $123 :: Number }');
     eq (show ($.RecordType ({0: $.Number, 1: $.Number}))) ('{ "0" :: Number, "1" :: Number }');
     eq (show ($.RecordType ({'foo-bar': $.Number}))) ('{ "foo-bar" :: Number }');
     eq (show ($.RecordType ({'foo bar': $.Number}))) ('{ "foo bar" :: Number }');
     eq (show ($.RecordType ({'x "y" z': $.Number}))) ('{ "x \\"y\\" z" :: Number }');
+
+    //  Field ordering:
+    eq (show ($.RecordType ({foo: $.Number, bar: $.Number}))) ('{ foo :: Number, bar :: Number }');
+    eq (show ($.RecordType ({bar: $.Number, foo: $.Number}))) ('{ bar :: Number, foo :: Number }');
 
     const pred = $.test ([]) ($.RecordType ({x: $.Number}));
 
@@ -1102,9 +1106,9 @@ See https://github.com/sanctuary-js/sanctuary-def/tree/v${version}#Number for in
     throws (() => { length ({start: 0, end: 0}); })
            (new TypeError (`Invalid value
 
-length :: { end :: { x :: Number, y :: Number }, start :: { x :: Number, y :: Number } } -> Number
-                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-                                1
+length :: { start :: { x :: Number, y :: Number }, end :: { x :: Number, y :: Number } } -> Number
+                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+                                  1
 
 1)  0 :: Number
 
@@ -1114,9 +1118,9 @@ The value at position 1 is not a member of ‘{ x :: Number, y :: Number }’.
     throws (() => { length ({start: {x: 0, y: 0}, end: {x: null, y: null}}); })
            (new TypeError (`Invalid value
 
-length :: { end :: { x :: Number, y :: Number }, start :: { x :: Number, y :: Number } } -> Number
-                          ^^^^^^
-                            1
+length :: { start :: { x :: Number, y :: Number }, end :: { x :: Number, y :: Number } } -> Number
+                                                                 ^^^^^^
+                                                                   1
 
 1)  null :: Null
 
@@ -3850,6 +3854,14 @@ suite ('interoperability', () => {
     eq (Z.equals ($.Array ($.NullaryType ('X') ('http://x.com/') ([]) (x => true)),
                   $.Array ($.NullaryType ('X') ('http://x.org/') ([]) (x => true))))
        (false);
+
+    //  Field ordering:
+    eq (Z.equals ($.RecordType ({foo: $.Number, bar: $.Number}),
+                  $.RecordType ({foo: $.Number, bar: $.Number})))
+       (true);
+    eq (Z.equals ($.RecordType ({foo: $.Number, bar: $.Number}),
+                  $.RecordType ({bar: $.Number, foo: $.Number})))
+       (true);
   });
 
 });


### PR DESCRIPTION
The fields of a record type may be specified in some logical order, so it is a shame to reorder the fields in the type's string representation. This pull request removes the use of `Array#sort`; a record type's fields are now enumerated in their inherent order rather than in alphabetical order. This also affects the order in which type checking is performed.

If one is defining a record type whose fields are not logically related, one can of course *specify* the fields in alphabetical order.

If this pull request is merged, equivalent record types may have different string representations despite being equal according to `Z.equals`. Although this is unfortunate, it is not without precedent:

```javascript
> Z.equals (0, -0)
true

> show (0)
'0'

> show (-0)
'-0'
```

`Z.equals` does not even guarantee the interchangeability of equal values with the *same* string representation:

```javascript
> Z.equals ({}, Object.create (null))
true

> 'toString' in {}
true

> 'toString' in Object.create (null)
false
```
