### PR TITLE
preserve ordering when formatting constraints

### DIFF
--- a/index.js
+++ b/index.js
@@ -2329,7 +2329,7 @@
     inner           // :: String -> TypeClass -> String -> String
   ) {
     var $reprs = [];
-    (sortedKeys (constraints)).forEach (function(k) {
+    (Object.keys (constraints)).forEach (function(k) {
       var f = inner (k);
       constraints[k].forEach (function(typeClass) {
         $reprs.push (f (typeClass) (stripNamespace (typeClass) + ' ' + k));

--- a/test/index.js
+++ b/test/index.js
@@ -2986,6 +2986,18 @@ The value at position 1 is not a member of ‘a -> a -> a -> b’.
     eq (alt (Right (5)) (Left (6))) (Right (5));
     eq (alt (Right (7)) (Right (8))) (Right (7));
 
+    //  Constraint ordering:
+    eq (show (def ('elem')
+                  ({a: [Z.Setoid], f: [Z.Foldable]})
+                  ([a, f (a), $.Boolean])
+                  (curry2 (Z.elem))))
+       ('elem :: (Setoid a, Foldable f) => a -> f a -> Boolean');
+    eq (show (def ('elem')
+                  ({f: [Z.Foldable], a: [Z.Setoid]})
+                  ([a, f (a), $.Boolean])
+                  (curry2 (Z.elem))))
+       ('elem :: (Foldable f, Setoid a) => a -> f a -> Boolean');
+
     //    concat :: Semigroup a => a -> a -> a
     const concat =
     def ('concat')


### PR DESCRIPTION
Like #295, this pull request gives authors more influence on the string representations generated by sanctuary-def.
