### PR TITLE
make sure that sanctuary-def will run without "util" module

### DIFF
--- a/index.js
+++ b/index.js
@@ -186,9 +186,19 @@
 
   var util = {inspect: {}};
 
+  function alt(a, f) {
+    try {
+      return f ();
+    } catch (e) {
+      /* istanbul ignore next */
+      return a;
+    }
+  }
+
   /* istanbul ignore else */
   if (typeof module === 'object' && typeof module.exports === 'object') {
-    module.exports = f (require ('util'),
+    module.exports = f (
+                        alt (util, function() { return require ('util'); }),
                         require ('sanctuary-either'),
                         require ('sanctuary-show'),
                         require ('sanctuary-type-classes'),


### PR DESCRIPTION
Fix so sanctuary-def can be used in CommonJS enviroments that does
not have the `util` module, such as scrimba.com.

Here is an example with sanctuary-def 0.22.0:
https://scrimba.com/scrim/cQGBN6cM

The def test "returns a function with "inspect" and "@@show" methods"
fails with the default `util` object but I guess you already know
that.

This will hopefully fix issue #300 but I guess the only way to know for sure is to publish and test it out on scrimba.com.