### PR TITLE
eslint: use "readonly" for globals in place of deprecated value

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -36,7 +36,7 @@
     },
     {
       "files": ["index.js"],
-      "globals": {"Deno": false, "Symbol": false},
+      "globals": {"Deno": "readonly", "Symbol": "readonly"},
       "rules": {
         "multiline-comment-style": ["off"]
       }


### PR DESCRIPTION
Relates to sanctuary-js/sanctuary-style#33
