### PR TITLE
fix test for HtmlElement type

### DIFF
--- a/index.js
+++ b/index.js
@@ -716,7 +716,11 @@
     ('HtmlElement')
     ([])
     (function(x) {
-       return /^\[object HTML.+Element\]$/.test (toString.call (x));
+      return (
+        x && x.toString && /^\[object HTML.*Element\]$/.test (x.toString ())
+        ||
+        false
+      );
      });
 
   //# Identity :: Type -> Type


### PR DESCRIPTION
This PR addresses the issue of `HtmlElement`'s test not working for HTMLElements as described in #309.

Currently, the test will always fail because `Object.toString.call` on an HTMLElement produces an error.

In Gecko (Firefox) the error is: "TypeError: Function.prototype.toString called on incompatible object"

In Blink (Chrome, Edge) the error is: "TypeError: Function.prototype.toString requires that 'this' be a Function"

This PR does not contain any new unit tests.