### PR TITLE
types: fix HtmlElement predicate

### DIFF
--- a/index.js
+++ b/index.js
@@ -716,7 +716,7 @@
     ('HtmlElement')
     ([])
     (function(x) {
-       return /^\[object HTML.+Element\]$/.test (toString.call (x));
+       return /^\[object HTML.*Element\]$/.test (toString.call (x));
      });
 
   //# Identity :: Type -> Type

--- a/test/index.js
+++ b/test/index.js
@@ -1672,6 +1672,10 @@ See https://github.com/sanctuary-js/sanctuary-def/tree/v${version}#Array2 for in
     eq ($.HtmlElement.name) ('HtmlElement');
     eq ($.HtmlElement.url) (`https://github.com/sanctuary-js/sanctuary-def/tree/v${version}#HtmlElement`);
     eq ($.HtmlElement.supertypes) ([]);
+
+    const isHtmlElement = $.test ([]) ($.HtmlElement);
+    eq (isHtmlElement ({[Symbol.toStringTag]: 'HTMLDivElement'})) (true);
+    eq (isHtmlElement ({[Symbol.toStringTag]: 'HTMLElement'})) (true);
   });
 
   test ('provides the "Identity" type constructor', () => {


### PR DESCRIPTION
Fixes #309

```javascript
> Object.prototype.toString.call (document.createElement ('div'))
'[object HTMLDivElement]'

> Object.prototype.toString.call (document.createElement ('section'))
'[object HTMLElement]'
```

Before:

```javascript
> /^\[object HTML.+Element\]$/.test (Object.prototype.toString.call (document.createElement ('section')))
false
```

After:

```javascript
> /^\[object HTML.*Element\]$/.test (Object.prototype.toString.call (document.createElement ('section')))
true
```

/cc @dotnetCarpenter
