### PR TITLE
shared mutable environment

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -2,6 +2,10 @@
   "root": true,
   "extends": ["./node_modules/sanctuary-style/eslint.json"],
   "parserOptions": {"ecmaVersion": 2020, "sourceType": "module"},
+  "rules": {
+    "comma-dangle": ["off"],
+    "no-param-reassign": ["off"]
+  },
   "overrides": [
     {
       "files": ["*.md"],
@@ -15,7 +19,6 @@
       "files": ["index.js"],
       "globals": {"globalThis": "readonly"},
       "rules": {
-        "comma-dangle": ["off"],
         "multiline-comment-style": ["off"]
       }
     }

--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -1,7 +1,7 @@
 {
   "root": true,
   "extends": ["../node_modules/sanctuary-style/eslint.json"],
-  "parserOptions": {"ecmaVersion": 2020, "sourceType": "module"},
+  "parserOptions": {"ecmaVersion": 2022, "sourceType": "module"},
   "env": {"node": true},
   "rules": {
     "max-len": ["off"]

--- a/test/module.js
+++ b/test/module.js
@@ -3,8 +3,7 @@ import * as $ from '../index.js';
 
 const a = $.TypeVariable ('a');
 
-$.create
-  ({checkTypes: true, env: $.env})
+$.def
   ('I')
   ({})
   ([a, a])


### PR DESCRIPTION
This may be the most significant change ever made to the way sanctuary-def works.

This library was built with purity in mind. Type variables in a definition only knew about the set of types closed over by the `def` function being used. This had far-reaching implications: Sanctuary users working with custom types needed to use a special function ([`S.create`][1]) to create a Sanctuary module whose polymorphic functions could recognize values of these types. This meant that tree shaking would remain impossible for many users even if the Sanctuary source code were to be converted to ECMAScript modules.

This pull request replaces the pure approach with an impure one. The environment, `$.config.env`, is now *shared* by all modules that depend on sanctuary-def. It is also (intentionally) *mutable*. Adding a type to this array will make all functions defined via `def` aware of this type. This applies to functions previously defined via `def` and to functions defined via `def` in the future.

Type checking is now enabled or disabled by assigning `true` or `false` respectively to `$.config.checkTypes`.

As there is now a shared environment and a shared Boolean indicating whether type checking should be performed, we need not support the creation of multiple `def` functions. This pull request introduces `$.def`, which makes `$.create` redundant.

This pull request also removes the dependence on the `NODE_ENV` environment variable.


[1]: https://github.com/sanctuary-js/sanctuary/tree/v3.1.0#create
