### PR TITLE
use `globalThis` and `?.` operator to simplify feature detection

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,7 @@
 {
   "root": true,
   "extends": ["./node_modules/sanctuary-style/eslint.json"],
+  "parserOptions": {"ecmaVersion": 2020},
   "overrides": [
     {
       "files": ["*.md"],
@@ -12,7 +13,7 @@
     },
     {
       "files": ["index.js"],
-      "globals": {"Deno": "readonly", "Symbol": "readonly"},
+      "globals": {"Symbol": "readonly", "globalThis": "readonly"},
       "rules": {
         "multiline-comment-style": ["off"]
       }

--- a/index.js
+++ b/index.js
@@ -505,8 +505,7 @@
   const Buffer_ = NullaryTypeWithUrl
     ('Buffer')
     ([])
-    // eslint-disable-next-line no-undef
-    (x => typeof Buffer !== 'undefined' && Buffer.isBuffer (x));
+    (x => globalThis.Buffer != null && globalThis.Buffer.isBuffer (x));
 
   //# Date :: Type
   //.
@@ -996,12 +995,7 @@
   const Unchecked = s => NullaryType (s) ('') ([]) (x => true);
 
   //  production :: Boolean
-  const production =
-    typeof process !== 'undefined' &&
-    /* global process:false */
-    process != null &&
-    process.env != null &&
-    process.env.NODE_ENV === 'production';
+  const production = globalThis.process?.env?.NODE_ENV === 'production';
 
   //  numbers :: Array String
   const numbers = [
@@ -2644,17 +2638,12 @@
 
     wrapped.toString = () => typeSignature (typeInfo);
     /* istanbul ignore else */
-    if (
-      typeof process !== 'undefined' &&
-      process != null &&
-      process.versions != null &&
-      process.versions.node != null
-    ) wrapped[Symbol.for ('nodejs.util.inspect.custom')] = wrapped.toString;
+    if (globalThis.process?.versions?.node != null) {
+      wrapped[Symbol.for ('nodejs.util.inspect.custom')] = wrapped.toString;
+    }
     /* istanbul ignore if */
-    if (typeof Deno !== 'undefined') {
-      if (Deno != null && typeof Deno.customInspect === 'symbol') {
-        wrapped[Deno.customInspect] = wrapped.toString;
-      }
+    if (typeof globalThis.Deno?.customInspect === 'symbol') {
+      wrapped[globalThis.Deno.customInspect] = wrapped.toString;
     }
 
     return wrapped;

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test": "npm run lint && sanctuary-test && npm run doctest"
   },
   "engines": {
-    "node": ">=10.12.0"
+    "node": ">=14.0.0"
   },
   "dependencies": {
     "sanctuary-either": "2.1.0",


### PR DESCRIPTION
I find `globalThis.Foo != null` clearer than `typeof Foo !== 'undefined' && Foo != null`, and it has the added benefit of not concerning ESLint.
