### PR TITLE
broaden and future-proof `RegexFlags`

### DIFF
--- a/index.js
+++ b/index.js
@@ -896,16 +896,15 @@ export const String = NullaryTypeWithUrl
 
 //# RegexFlags :: Type
 //.
-//. Type comprising the canonical RegExp flags *recognized by the runtime*.
-//. Characters must be alphabetically ordered. Repeated characters are not
-//. permitted. Invalid combinations (such as `'uv'`) are not permitted.
+//. Type comprising the RegExp flags *accepted by the runtime*.
+//. Repeated characters are not permitted. Invalid combinations
+//. (such as `'uv'`) are not permitted.
 export const RegexFlags = NullaryTypeWithUrl
   ('RegexFlags')
   ([String])
   (s => {
-     let regex;
-     try { regex = globalThis.RegExp ('', s); } catch { return false; }
-     return regex.flags === s;
+     try { globalThis.RegExp ('', s); } catch { return false; }
+     return true;
    });
 
 //# Symbol :: Type

--- a/index.js
+++ b/index.js
@@ -896,20 +896,17 @@ export const String = NullaryTypeWithUrl
 
 //# RegexFlags :: Type
 //.
-//. Type comprising the canonical RegExp flags:
-//.
-//.   - `''`
-//.   - `'g'`
-//.   - `'i'`
-//.   - `'m'`
-//.   - `'gi'`
-//.   - `'gm'`
-//.   - `'im'`
-//.   - `'gim'`
+//. Type comprising the canonical RegExp flags *recognized by the runtime*.
+//. Characters must be alphabetically ordered. Repeated characters are not
+//. permitted. Invalid combinations (such as `'uv'`) are not permitted.
 export const RegexFlags = NullaryTypeWithUrl
   ('RegexFlags')
   ([String])
-  (s => /^g?i?m?$/.test (s));
+  (s => {
+     let regex;
+     try { regex = globalThis.RegExp ('', s); } catch { return false; }
+     return regex.flags === s;
+   });
 
 //# Symbol :: Type
 //.

--- a/test/index.js
+++ b/test/index.js
@@ -1,5 +1,6 @@
 import {deepStrictEqual as eq, throws} from 'node:assert';
 import module from 'node:module';
+import process from 'node:process';
 import util from 'node:util';
 import vm from 'node:vm';
 
@@ -2160,12 +2161,16 @@ See https://github.com/sanctuary-js/sanctuary-def/tree/v${version}#ValidDate for
     eq (isRegexFlags ('gm'), true);
     eq (isRegexFlags ('im'), true);
     eq (isRegexFlags ('gim'), true);
+    eq (isRegexFlags ('dgimsuy'), true);
+    eq (isRegexFlags ('dgimsvy'), parseInt (process.versions.node, 10) >= 20);
     //  String objects are not acceptable.
     eq (isRegexFlags (new String ('')), false);
     //  Flags must be alphabetically ordered.
     eq (isRegexFlags ('mg'), false);
-    //  "Sticky" flag is not acceptable.
-    eq (isRegexFlags ('y'), false);
+    //  Flags cannot contain repeated characters.
+    eq (isRegexFlags ('gg'), false);
+    //  Flags cannot contain both 'u' and 'v'.
+    eq (isRegexFlags ('uv'), false);
   });
 
   test ('provides the "StrMap" type constructor', () => {

--- a/test/index.js
+++ b/test/index.js
@@ -2165,8 +2165,8 @@ See https://github.com/sanctuary-js/sanctuary-def/tree/v${version}#ValidDate for
     eq (isRegexFlags ('dgimsvy'), parseInt (process.versions.node, 10) >= 20);
     //  String objects are not acceptable.
     eq (isRegexFlags (new String ('')), false);
-    //  Flags must be alphabetically ordered.
-    eq (isRegexFlags ('mg'), false);
+    //  Flags need not be alphabetically ordered.
+    eq (isRegexFlags ('mg'), true);
     //  Flags cannot contain repeated characters.
     eq (isRegexFlags ('gg'), false);
     //  Flags cannot contain both 'u' and 'v'.


### PR DESCRIPTION
`RegexFlags` is woefully out of date. This pull request updates the type's predicate and obviates the need for future updates.
